### PR TITLE
Send reminders on the day specified instead of the day after

### DIFF
--- a/bugbot/rules/reminder.py
+++ b/bugbot/rules/reminder.py
@@ -61,7 +61,7 @@ class Reminder(BzCleaner):
                 reminders.append({"full_tag": replace_string, "invalid_date": True})
                 continue
 
-            if parsed_date < self.today:
+            if parsed_date <= self.today:
                 replace_string = f"[reminder-{tag} {date}]"
                 new_whiteboard = new_whiteboard.replace(replace_string, "")
                 reminders.append({"full_tag": replace_string})


### PR DESCRIPTION
This was discussed in #developers on matrix.

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
