### PR TITLE
Don't autoclose security bugs where there is a needinfo on an inactive reporter

### DIFF
--- a/bugbot/constants.py
+++ b/bugbot/constants.py
@@ -19,3 +19,6 @@ OLD_SEVERITY_MAP = {
     "trivial": "S4",
     "enhancement": "S4",
 }
+
+HIGH_SECURITY_KEYWORDS = ["sec-high", "sec-critical"]
+SECURITY_KEYWORDS = HIGH_SECURITY_KEYWORDS + ["sec-moderate", "sec-low"]

--- a/bugbot/rules/inactive_ni_pending.py
+++ b/bugbot/rules/inactive_ni_pending.py
@@ -10,7 +10,7 @@ from libmozdata import utils as lmdutils
 
 from bugbot import utils
 from bugbot.bzcleaner import BzCleaner
-from bugbot.constants import HIGH_PRIORITY, HIGH_SEVERITY
+from bugbot.constants import HIGH_PRIORITY, HIGH_SEVERITY, SECURITY_KEYWORDS
 from bugbot.user_activity import UserActivity, UserStatus
 from bugbot.utils import plural
 
@@ -149,6 +149,7 @@ class InactiveNeedinfoPending(BzCleaner):
             bug["priority"] in HIGH_PRIORITY
             or bug["severity"] in HIGH_SEVERITY
             or bug["last_change_time"] >= RECENT_BUG_LIMIT
+            or any(keyword in SECURITY_KEYWORDS for keyword in bug["keywords"])
         ):
             return NeedinfoAction.FORWARD
 
@@ -287,6 +288,7 @@ class InactiveNeedinfoPending(BzCleaner):
             "needinfo_flags": [
                 flag for flag in bug["flags"] if flag["name"] == "needinfo"
             ],
+            "keywords": bug["keywords"],
         }
 
         return bug
@@ -303,6 +305,7 @@ class InactiveNeedinfoPending(BzCleaner):
             "creation_time",
             "comments",
             "creator",
+            "keywords",
         ]
 
         params = {

--- a/bugbot/rules/severity_high_security.py
+++ b/bugbot/rules/severity_high_security.py
@@ -4,8 +4,7 @@
 
 from bugbot import utils
 from bugbot.bzcleaner import BzCleaner
-
-HIGH_SECURITY_KEYWORDS = ["sec-high", "sec-critical"]
+from bugbot.constants import HIGH_SECURITY_KEYWORDS
 
 
 class SeverityHighSecurity(BzCleaner):


### PR DESCRIPTION
Fixes #2097

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
