### PR TITLE
Turn off BugBug for the Web Compatibility product.

### DIFF
--- a/configs/rules.json
+++ b/configs/rules.json
@@ -50,7 +50,6 @@
       "Remote Protocol",
       "Testing",
       "Toolkit",
-      "Web Compatibility",
       "WebExtensions"
     ],
     "log": "/tmp/bugbot_errors.txt",
@@ -271,11 +270,7 @@
       "Core::MFBT",
       "WebExtensions::Developer Outreach",
       "NSS::Tools",
-      "NSS::Build",
-      "Web Compatibility::Desktop",
-      "Web Compatibility::Interventions",
-      "Web Compatibility::Mobile",
-      "Web Compatibility::Tooling & Investigations"
+      "NSS::Build"
     ],
     "supervisor_skiplist": ["dcamp@mozilla.com"]
   },


### PR DESCRIPTION
It was already disabled on all existing components. However, we recently added another component called "Knowledge Base", where we also do not want to get nagged, as some flags depend on internal processes.

Instead of adding another Component-exception, let's turn it off for the entire product.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
