### PR TITLE
Restore previous workarounds for out-of-sync uplift flags

### DIFF
--- a/scripts/cron_run_weekdays.sh
+++ b/scripts/cron_run_weekdays.sh
@@ -145,7 +145,8 @@ python -m bugbot.rules.inactive_ni_pending --production
 python -m bugbot.rules.crash_signature_confirm --production
 
 # Bugs with patches after being closed
-python -m bugbot.rules.patch_closed_bug --production
+# Disabled temporarily until fixing https://github.com/mozilla/bugbot/issues/1953
+# python -m bugbot.rules.patch_closed_bug --production
 
 # Confirm bugs with affected flags
 python -m bugbot.rules.affected_flag_confirm --production


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
This PR adds workarounds for #1953 and #2167.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
