### PR TITLE
Ensure SMTP over SSL verifies the server certificate

### DIFF
--- a/bugbot/mail.py
+++ b/bugbot/mail.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import smtplib
+import ssl
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -126,7 +127,8 @@ def sendMail(From, To, msg, login={}, dryrun=False):
     smtp_ssl = login.get("smtp_ssl", default_login.get("smtp_ssl", True))
 
     if smtp_ssl:
-        mailserver = smtplib.SMTP_SSL(smtp_server, smtp_port)
+        mailserver = smtplib.SMTP_SSL(smtp_server, smtp_port,
+                                      context=ssl.create_default_context())
     else:
         mailserver = smtplib.SMTP(smtp_server, smtp_port)
 

--- a/bugbot/mail.py
+++ b/bugbot/mail.py
@@ -127,8 +127,9 @@ def sendMail(From, To, msg, login={}, dryrun=False):
     smtp_ssl = login.get("smtp_ssl", default_login.get("smtp_ssl", True))
 
     if smtp_ssl:
-        mailserver = smtplib.SMTP_SSL(smtp_server, smtp_port,
-                                      context=ssl.create_default_context())
+        mailserver = smtplib.SMTP_SSL(
+            smtp_server, smtp_port, context=ssl.create_default_context()
+        )
     else:
         mailserver = smtplib.SMTP(smtp_server, smtp_port)
 


### PR DESCRIPTION
This patch supplies an ssl context to the `SMTP_SSL` constructor, which enables certificate verification. The default context will use the system's trusted CA certificates. See https://docs.python.org/3/library/ssl.html#ssl-security for more.

Kudos to Martin Schobert and Tobias Ospelt of Pentagrid AG for reporting to Mozilla Security.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

It looks none of the item in the checklist are really applicable here.

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing


