### PR TITLE
[variant_expiration] Do not rely on `is_patch` to identify patches

### DIFF
--- a/bugbot/rules/variant_expiration.py
+++ b/bugbot/rules/variant_expiration.py
@@ -340,11 +340,13 @@ class VariantExpiration(BzCleaner, Nag):
         return bug
 
     def is_with_patch(self, bug: dict) -> bool:
-        """Check if the bug has a patch"""
+        """Check if the bug has a patch (not obsolete))"""
         return any(
-            attachment["is_patch"]
-            and not attachment["is_obsolete"]
-            and attachment["content_type"] == "text/x-phabricator-request"
+            not attachment["is_obsolete"]
+            and (
+                attachment["content_type"] == "text/x-phabricator-request"
+                or attachment["is_patch"]
+            )
             for attachment in bug["attachments"]
         )
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Fixes #2206 

When the attachment is a link to Phabricator, the value of `is_patch` will be `0` since the attachment itself is not a patch. Therefore, using `is_patch` to determine if an attachment is a patch will prevent the bot from recognizing that there is a patch attached.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
