### PR TITLE
[topcrash_highlight] Disable re-adding top crash keywords

### DIFF
--- a/bugbot/rules/topcrash_highlight.py
+++ b/bugbot/rules/topcrash_highlight.py
@@ -50,15 +50,29 @@ class TopcrashHighlight(BzCleaner):
             },
         }
 
-        if keywords_to_add and (
-            not is_keywords_removed
-            or self._is_matching_restrictive_criteria(topcrash_signatures)
-        ):
+        if keywords_to_add and not is_keywords_removed:
             autofix["keywords"] = {"add": keywords_to_add}
             autofix["comment"]["body"] += self.get_matching_criteria_comment(
                 topcrash_signatures, is_keywords_removed
             )
             actions.extend(f"Add {keyword} keyword" for keyword in keywords_to_add)
+
+        if (
+            keywords_to_add
+            and is_keywords_removed
+            and self._is_matching_restrictive_criteria(topcrash_signatures)
+        ):
+            # FIXME: This is a workaround to monitor the cases where the bot
+            # supposed re-add topcrash keywords.
+            # More context in: https://github.com/mozilla/bugbot/issues/2100
+            actions.extend(
+                f"Add {keyword} keyword (not applied to avoid noise)"
+                for keyword in keywords_to_add
+            )
+            data[bugid] = {
+                "actions": actions,
+            }
+            return
 
         ni_person = utils.get_mail_to_ni(bug)
         if (


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

This should prevent unnecessary noise until we fix the bug in https://github.com/mozilla/bugbot/issues/2100

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
