### PR TITLE
[file_crash_bug] Fix detecting addresses with near allocator poison values

### DIFF
--- a/bugbot/crash/analyzer.py
+++ b/bugbot/crash/analyzer.py
@@ -38,10 +38,10 @@ ALLOCATOR_ADDRESSES_32_BIT = (
     (0x4B4B4B4B, OFFSET_32_BIT),
 )
 # Ranges where addresses are considered near allocator poison values.
-ALLOCATOR_RANGES_64_BIT = (
+ALLOCATOR_RANGES_64_BIT = tuple(
     (addr - offset, addr + offset) for addr, offset in ALLOCATOR_ADDRESSES_64_BIT
 )
-ALLOCATOR_RANGES_32_BIT = (
+ALLOCATOR_RANGES_32_BIT = tuple(
     (addr - offset, addr + offset) for addr, offset in ALLOCATOR_ADDRESSES_32_BIT
 )
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Fixes #2258 

It's a stupid bug where the constant gets created as a `generator` instead of a `tuple`. As a result, the first time we call the `is_near_allocator_address()` function, we get a correct result, but subsequent calls always return `False`.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
