### PR TITLE
add a new rule to notify bugs with a lot of comments

### DIFF
--- a/bugbot/rules/lot_of_comments.py
+++ b/bugbot/rules/lot_of_comments.py
@@ -50,5 +50,6 @@ class SeveralComments(BzCleaner):
             "v3": ["meta", "intermittent"],
         }
 
+
 if __name__ == "__main__":
     SeveralComments().run()

--- a/bugbot/rules/lot_of_comments.py
+++ b/bugbot/rules/lot_of_comments.py
@@ -7,17 +7,22 @@ from bugbot.bzcleaner import BzCleaner
 
 
 class SeveralComments(BzCleaner):
-    def __init__(self):
-        super(SeveralComments, self).__init__()
-        self.nweeks = utils.get_config(self.name(), "weeks_lookup")
-        self.comments = utils.get_config(self.name(), "number_comments")
-        print("foo")
+    def __init__(self, nweeks: int = 52, comments: int = 50):
+        """Constructor
+
+        Args:
+            nweeks: the maximum number of weeks from the submission date
+            comments: the number of comments in the bug
+        """
+        super().__init__()
+        self.nweeks = nweeks
+        self.comments = comments
 
     def description(self):
         return "Bugs with several comments for the last {} weeks".format(self.nweeks)
 
     def columns(self):
-        return ["id", "summary", "creation", "last_change"]
+        return ["id", "summary", "creation", "last_change", "comment_count"]
 
     def handle_bug(self, bug, data):
         bugid = str(bug["id"])
@@ -31,8 +36,7 @@ class SeveralComments(BzCleaner):
         return bug
 
     def get_bz_params(self, date):
-        print("foo")
-        params = {
+        return {
             "include_fields": ["creation_time", "last_change_time", "comment_count"],
             "resolution": "---",
             "f1": "days_elapsed",
@@ -45,9 +49,6 @@ class SeveralComments(BzCleaner):
             "o3": "nowords",
             "v3": ["meta", "intermittent"],
         }
-        print(params)
-        return params
-
 
 if __name__ == "__main__":
     SeveralComments().run()

--- a/bugbot/rules/lot_of_comments.py
+++ b/bugbot/rules/lot_of_comments.py
@@ -1,0 +1,53 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from bugbot import utils
+from bugbot.bzcleaner import BzCleaner
+
+
+class SeveralComments(BzCleaner):
+    def __init__(self):
+        super(SeveralComments, self).__init__()
+        self.nweeks = utils.get_config(self.name(), "weeks_lookup")
+        self.comments = utils.get_config(self.name(), "number_comments")
+        print("foo")
+
+    def description(self):
+        return "Bugs with several comments for the last {} weeks".format(self.nweeks)
+
+    def columns(self):
+        return ["id", "summary", "creation", "last_change"]
+
+    def handle_bug(self, bug, data):
+        bugid = str(bug["id"])
+        comment_count = bug["comment_count"]
+
+        data[bugid] = {
+            "creation": utils.get_human_lag(bug["creation_time"]),
+            "last_change": utils.get_human_lag(bug["last_change_time"]),
+            "comment_count": comment_count,
+        }
+        return bug
+
+    def get_bz_params(self, date):
+        print("foo")
+        params = {
+            "include_fields": ["creation_time", "last_change_time", "comment_count"],
+            "resolution": "---",
+            "f1": "days_elapsed",
+            "o1": "lessthan",
+            "v1": self.nweeks * 7,
+            "f2": "longdescs.count",
+            "o2": "greaterthaneq",
+            "v2": self.comments,
+            "f3": "keywords",
+            "o3": "nowords",
+            "v3": ["meta", "intermittent"],
+        }
+        print(params)
+        return params
+
+
+if __name__ == "__main__":
+    SeveralComments().run()

--- a/configs/rules.json
+++ b/configs/rules.json
@@ -172,9 +172,8 @@
     "must_run": ["Mon"]
   },
   "lot_of_comments": {
-    "weeks_lookup": 52,
-    "number_comments": 50,
-    "additional_receivers": "rm"
+    "additional_receivers": "rm",
+    "must_run": ["Mon"]
   },
   "severity_underestimated": {
     "weeks_lookup": 3,

--- a/configs/rules.json
+++ b/configs/rules.json
@@ -171,6 +171,11 @@
     "additional_receivers": "rm",
     "must_run": ["Mon"]
   },
+  "lot_of_comments": {
+    "weeks_lookup": 52,
+    "number_comments": 50,
+    "additional_receivers": "rm"
+  },
   "severity_underestimated": {
     "weeks_lookup": 3,
     "number_dups": 3,

--- a/scripts/check_rules_on_wiki.py
+++ b/scripts/check_rules_on_wiki.py
@@ -47,6 +47,7 @@ class CheckWikiPage:
         "several_dups.py",
         "lot_of_votes.py",
         "lot_of_cc.py",
+        "lot_of_comments.py",
         "pdfjs_tag_change.py",
         "pdfjs_update.py",
         "leave_open_sec.py",

--- a/scripts/cron_run_weekdays.sh
+++ b/scripts/cron_run_weekdays.sh
@@ -82,6 +82,9 @@ python -m bugbot.rules.lot_of_cc --production
 # Bugs with a lot of votes
 python -m bugbot.rules.lot_of_votes --production
 
+# Bugs with a lot of comments
+python -m bugbot.rules.lot_of_comments --production
+
 # Bug caused several regressions recently reported
 # Pretty rare
 python -m bugbot.rules.warn_regressed_by --production

--- a/templates/lot_of_comments.html
+++ b/templates/lot_of_comments.html
@@ -5,11 +5,12 @@
             <th>Bug</th>
             <th>Summary</th>
             <th>Creation</th>
+            <th># of comments</th>
             <th>Last comment</th>
         </tr>
     </thead>
     <tbody>
-        {% for i, (bugid, summary, creation, last_change) in enumerate(data) -%}
+        {% for i, (bugid, summary, creation, last_change, comment_count) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
@@ -19,6 +20,7 @@
             <td>{{ summary | e }}</td>
             <td>{{ creation }}</td>
             <td>{{ last_change }}</td>
+            <td>{{ comment_count }}</td>
         </tr>
     {% endfor -%}
 </tbody>

--- a/templates/lot_of_comments.html
+++ b/templates/lot_of_comments.html
@@ -5,8 +5,8 @@
             <th>Bug</th>
             <th>Summary</th>
             <th>Creation</th>
-            <th># of comments</th>
             <th>Last comment</th>
+            <th># of comments</th>
         </tr>
     </thead>
     <tbody>

--- a/templates/lot_of_comments.html
+++ b/templates/lot_of_comments.html
@@ -1,0 +1,25 @@
+<p>The following {{ plural('bug has', data, pword='bugs have') }} many comments:</p>
+<table {{ table_attrs }}>
+    <thead>
+        <tr>
+            <th>Bug</th>
+            <th>Summary</th>
+            <th>Creation</th>
+            <th>Last comment</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for i, (bugid, summary, creation, last_change) in enumerate(data) -%}
+            <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
+            {% endif -%}
+            >
+            <td>
+                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+            </td>
+            <td>{{ summary | e }}</td>
+            <td>{{ creation }}</td>
+            <td>{{ last_change }}</td>
+        </tr>
+    {% endfor -%}
+</tbody>
+</table>


### PR DESCRIPTION
Dry run:
```
****************************
* DRYRUN: not sending mail *
****************************
Receivers: ['calixte@mozilla.com', 'sylvestre@mozilla.com', 'mcastelluccio@mozilla.com', 'smujahid@mozilla.com', 'release-mgmt@mozilla.com']
Message:
Content-Type: multipart/mixed; boundary="===============0348191179176360971=="
MIME-Version: 1.0
From: xxx@xxxx.xxx
To: calixte@mozilla.com, sylvestre@mozilla.com, mcastelluccio@mozilla.com, smujahid@mozilla.com, release-mgmt@mozilla.com
Subject: [bugbot] Bugs with several comments for the last 52 weeks for the 2023-11-13
Cc:
Bcc:
X-Mailer: bugbot

--===============0348191179176360971==
Content-Type: text/html; charset="us-ascii"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit

<!DOCTYPE html>
<html lang="en-us">
    <head>
        <meta charset="utf-8">
    </head>
    <body>
        <p>Hi there,</p>

        <p>The following bugs have many comments:</p>
<table style="border:1px solid black;border-collapse:collapse;" border="1">
    <thead>
        <tr>
            <th>Bug</th>
            <th>Summary</th>
            <th>Creation</th>
            <th>Last comment</th>
        </tr>
    </thead>
    <tbody>
        <tr bgcolor="#E0E0E0"
            >
            <td>
                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1852554">1852554</a>
            </td>
            <td>Firefox Nightly Snap identifying different invocation methods as different processes and assigning separate profiles.</td>
            <td>2 months</td>
            <td>a month</td>
[...]
```