### PR TITLE
Reorder hourly rules to run `file_crash_bug` before `component`

### DIFF
--- a/scripts/cron_run_hourly.sh
+++ b/scripts/cron_run_hourly.sh
@@ -38,6 +38,9 @@ python -m bugbot.rules.stalled --production
 # Pretty rare
 python -m bugbot.rules.missing_beta_status --production
 
+# File bugs for new actionable crashes
+python -m bugbot.rules.file_crash_bug --production
+
 # Try to detect potential regressions using bugbug
 python -m bugbot.rules.regression --production
 
@@ -72,8 +75,5 @@ python -m bugbot.rules.multifix_regression --production
 
 # Copy metadata from duplicates
 python -m bugbot.rules.duplicate_copy_metadata --production
-
-# File bugs for new actionable crashes
-python -m bugbot.rules.file_crash_bug --production
 
 source ./scripts/cron_common_end.sh


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Fixes #2278 

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
