### PR TITLE
Use `product::component` to refer to components in all emails

### DIFF
--- a/bugbot/rules/assignee_no_login.py
+++ b/bugbot/rules/assignee_no_login.py
@@ -42,6 +42,7 @@ class AssigneeNoLogin(BzCleaner):
     def columns(self):
         return [
             "triage_owner_name",
+            "product",
             "component",
             "id",
             "summary",

--- a/bugbot/rules/to_triage.py
+++ b/bugbot/rules/to_triage.py
@@ -42,7 +42,7 @@ class ToTriage(BzCleaner, Nag):
         return True
 
     def columns(self):
-        return ["component", "id", "summary", "type"]
+        return ["product", "component", "id", "summary", "type"]
 
     def columns_nag(self):
         return self.columns()

--- a/bugbot/rules/workflow/no_severity.py
+++ b/bugbot/rules/workflow/no_severity.py
@@ -74,7 +74,7 @@ class NoSeverity(BzCleaner, Nag):
         return True
 
     def columns(self):
-        return ["component", "id", "summary"]
+        return ["product", "component", "id", "summary"]
 
     def handle_bug(self, bug, data):
         if (

--- a/bugbot/rules/workflow/p1_no_activity.py
+++ b/bugbot/rules/workflow/p1_no_activity.py
@@ -42,7 +42,7 @@ class P1NoActivity(BzCleaner, Nag):
         return True
 
     def columns(self):
-        return ["component", "id", "summary", "last_comment", "assignee"]
+        return ["product", "component", "id", "summary", "last_comment", "assignee"]
 
     def set_people_to_nag(self, bug, buginfo):
         priority = "high"

--- a/bugbot/rules/workflow/p1_no_assignee.py
+++ b/bugbot/rules/workflow/p1_no_assignee.py
@@ -47,7 +47,7 @@ class P1NoAssignee(BzCleaner, Nag):
         return True
 
     def columns(self):
-        return ["component", "id", "summary", "last_comment"]
+        return ["product", "component", "id", "summary", "last_comment"]
 
     def handle_bug(self, bug, data):
         # check if the product::component is in the list

--- a/bugbot/rules/workflow/p2_merge_day.py
+++ b/bugbot/rules/workflow/p2_merge_day.py
@@ -20,7 +20,7 @@ class P2MergeDay(BzCleaner):
         return True
 
     def columns(self):
-        return ["component", "id", "summary"]
+        return ["product", "component", "id", "summary"]
 
     def handle_bug(self, bug, data):
         # check if the product::component is in the list

--- a/bugbot/rules/workflow/p2_no_activity.py
+++ b/bugbot/rules/workflow/p2_no_activity.py
@@ -43,7 +43,7 @@ class P2NoActivity(BzCleaner, Nag):
         return True
 
     def columns(self):
-        return ["component", "id", "summary", "last_comment"]
+        return ["product", "component", "id", "summary", "last_comment"]
 
     def set_people_to_nag(self, bug, buginfo):
         priority = "default"

--- a/bugbot/rules/workflow/p3_p4_p5.py
+++ b/bugbot/rules/workflow/p3_p4_p5.py
@@ -27,7 +27,7 @@ class P3P4P5(BzCleaner):
         return True
 
     def columns(self):
-        return ["component", "id", "summary"]
+        return ["product", "component", "id", "summary"]
 
     def handle_bug(self, bug, data):
         # check if the product::component is in the list

--- a/templates/assignee_no_login.html
+++ b/templates/assignee_no_login.html
@@ -11,12 +11,12 @@
         </tr>
     </thead>
     <tbody>
-        {% for i, (triage_owner_name, comp, bugid, summary, assignee, assignee_status) in enumerate(data) -%}
+        {% for i, (triage_owner_name, product, comp, bugid, summary, assignee, assignee_status) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
             <td>{{ triage_owner_name | e }}</td>
-            <td>{{ comp | e }}</td>
+            <td>{{ product | e }}::{{ comp | e }}</td>
             <td>
                 <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
             </td>

--- a/templates/no_severity.html
+++ b/templates/no_severity.html
@@ -11,11 +11,11 @@
         </tr>
     </thead>
     <tbody>
-        {% for i, (comp, bugid, summary) in enumerate(data) -%}
+        {% for i, (product, comp, bugid, summary) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
-            <td>{{ comp | e }}</td>
+            <td>{{ product | e }}::{{ comp | e }}</td>
             <td>
                 <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
             </td>

--- a/templates/p1_no_activity.html
+++ b/templates/p1_no_activity.html
@@ -12,11 +12,11 @@
         </tr>
     </thead>
     <tbody>
-        {% for i, (comp, bugid, summary, last_comment, assignee) in enumerate(data) -%}
+        {% for i, (product, comp, bugid, summary, last_comment, assignee) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
-            <td>{{ comp | e }}</td>
+            <td>{{ product | e }}::{{ comp | e }}</td>
             <td>
                 <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
             </td>

--- a/templates/p1_no_assignee.html
+++ b/templates/p1_no_assignee.html
@@ -15,11 +15,11 @@
         </tr>
     </thead>
     <tbody>
-        {% for i, (comp, bugid, summary, last_comment) in enumerate(data) -%}
+        {% for i, (product, comp, bugid, summary, last_comment) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
-            <td>{{ comp | e }}</td>
+            <td>{{ product | e }}::{{ comp | e }}</td>
             <td>
                 <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
             </td>

--- a/templates/p2_merge_day.html
+++ b/templates/p2_merge_day.html
@@ -8,11 +8,11 @@
         </tr>
     </thead>
     <tbody>
-        {% for i, (component, bugid, summary) in enumerate(data) -%}
+        {% for i, (product, comp, bugid, summary) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
-            <td>{{ comp | e }}</td>
+            <td>{{ product | e }}::{{ comp | e }}</td>
             <td>
                 <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
             </td>

--- a/templates/p2_no_activity.html
+++ b/templates/p2_no_activity.html
@@ -15,11 +15,11 @@
         </tr>
     </thead>
     <tbody>
-        {% for i, (comp, bugid, summary, last_comment) in enumerate(data) -%}
+        {% for i, (product, comp, bugid, summary, last_comment) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
-            <td>{{ comp | e }}</td>
+            <td>{{ product | e }}::{{ comp | e }}</td>
             <td>
                 <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
             </td>

--- a/templates/p3_p4_p5.html
+++ b/templates/p3_p4_p5.html
@@ -10,11 +10,11 @@
         </tr>
     </thead>
     <tbody>
-        {% for i, (comp, bugid, summary) in enumerate(data) -%}
+        {% for i, (product, comp, bugid, summary) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
-            <td>{{ comp | e }}</td>
+            <td>{{ product | e }}::{{ comp | e }}</td>
             <td>
                 <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
             </td>

--- a/templates/to_triage.html
+++ b/templates/to_triage.html
@@ -11,11 +11,11 @@
         </tr>
     </thead>
     <tbody>
-        {% for i, (comp, bugid, summary, type) in enumerate(data) -%}
+        {% for i, (product, comp, bugid, summary, type) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
-            <td>{{ comp | e }}</td>
+            <td>{{ product | e }}::{{ comp | e }}</td>
             <td>
                 <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
             </td>


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Resolves #2295 

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
