### PR TITLE
[round_robin] Do not crash on invalid duty start dates

### DIFF
--- a/bugbot/round_robin.py
+++ b/bugbot/round_robin.py
@@ -12,7 +12,12 @@ from libmozdata.bugzilla import BugzillaUser
 from bugbot import logger, utils
 from bugbot.components import Components
 from bugbot.people import People
-from bugbot.round_robin_calendar import BadFallback, Calendar, InvalidCalendar
+from bugbot.round_robin_calendar import (
+    BadFallback,
+    Calendar,
+    InvalidCalendar,
+    InvalidDateError,
+)
 
 
 class RoundRobin(object):
@@ -77,7 +82,7 @@ class RoundRobin(object):
 
                     self.data[component_name] = calendar
 
-            except (BadFallback, InvalidCalendar) as err:
+            except (BadFallback, InvalidCalendar, InvalidDateError) as err:
                 logger.error(err)
                 # If one the team's calendars failed, it is better to fail loud,
                 # and disable all team's calendars.


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Resolves #2300 

Instead of crashing, with this PR, we will have something like the following:
```
2023-12-14 22:22:49,032 - ERROR - Invalid duty start date for the Performance Engineering team: day is out of range for month: 2023-02-29
```

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
