### PR TITLE
Add Pre-Commit Configuration Instructions to README File

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,16 @@ Installation
 
     pip install -r requirements.txt
 
+Auto-formatting with pre-commit
+-------------------------------
+
+This project is using [pre-commit](https://pre-commit.com/).
+
+#. Install the git pre-commit hooks on your clone::
+
+    pre-commit install
+
+Every time you will try to commit, pre-commit will run checks on your files to make sure they follow our style standards and they aren't affected by some simple issues. If the checks fail, pre-commit won't let you commit.
 
 Running the Bot Rules
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -38,13 +38,9 @@ This project uses `pre-commit <https://pre-commit.com/>`_.
 
 #. Install the required packages from `requirements-test.txt <requirements-test.txt>`_:
 
-.. code-block:: bash
-
     pip install -r requirements-test.txt
 
 #. After installing the required packages, set up the git pre-commit hooks in your clone:
-
-.. code-block:: bash
 
     pre-commit install
 

--- a/README.rst
+++ b/README.rst
@@ -36,11 +36,11 @@ Auto-formatting with pre-commit
 
 This project uses `pre-commit <https://pre-commit.com/>`_.
 
-#. Install the required packages from `requirements-test.txt <requirements-test.txt>`_::
+#. Install test dependencies, if not already installed::
 
     pip install -r requirements-test.txt
 
-#. After installing the required packages, set up the git pre-commit hooks in your clone::
+#. Set up the git pre-commit hooks in your clone::
 
     pre-commit install
 

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Installation
 Auto-formatting with pre-commit
 -------------------------------
 
-This project is using [pre-commit](https://pre-commit.com/).
+This project is using `pre-commit <https://pre-commit.com/>`_.
 
 #. Install the git pre-commit hooks on your clone::
 

--- a/README.rst
+++ b/README.rst
@@ -38,17 +38,17 @@ This project uses `pre-commit <https://pre-commit.com/>`_.
 
 #. Install the required packages from `requirements-test.txt <requirements-test.txt>`_:
 
-    .. code-block:: bash
-
-        pip install -r requirements-test.txt
+.. code-block:: bash
+    
+    pip install -r requirements-test.txt
 
 #. After installing the required packages, set up the git pre-commit hooks in your clone:
 
-    .. code-block:: bash
+.. code-block:: bash
+    
+    pre-commit install
 
-        pre-commit install
-
-Every time you will try to commit, pre-commit will run checks on your files to make sure they follow our style standards and they aren't affected by some simple issues. If the checks fail, pre-commit won't let you commit.
+Every time you try to commit, pre-commit checks your files to ensure they follow our style standards and aren't affected by some simple issues. If the checks fail, pre-commit won't let you commit.
 
 Running the Bot Rules
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Auto-formatting with pre-commit
 
 This project uses `pre-commit <https://pre-commit.com/>`_.
 
-#. Install the required packages from :file:`requirements-test.txt`:
+#. Install the required packages from `requirements-test.txt <requirements-test.txt>`_:
 
     .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -39,13 +39,13 @@ This project uses `pre-commit <https://pre-commit.com/>`_.
 #. Install the required packages from `requirements-test.txt <requirements-test.txt>`_:
 
 .. code-block:: bash
-    
+
     pip install -r requirements-test.txt
 
 #. After installing the required packages, set up the git pre-commit hooks in your clone:
 
 .. code-block:: bash
-    
+
     pre-commit install
 
 Every time you try to commit, pre-commit checks your files to ensure they follow our style standards and aren't affected by some simple issues. If the checks fail, pre-commit won't let you commit.

--- a/README.rst
+++ b/README.rst
@@ -36,11 +36,11 @@ Auto-formatting with pre-commit
 
 This project uses `pre-commit <https://pre-commit.com/>`_.
 
-#. Install the required packages from `requirements-test.txt <requirements-test.txt>`_:
+#. Install the required packages from `requirements-test.txt <requirements-test.txt>`_::
 
     pip install -r requirements-test.txt
 
-#. After installing the required packages, set up the git pre-commit hooks in your clone:
+#. After installing the required packages, set up the git pre-commit hooks in your clone::
 
     pre-commit install
 

--- a/README.rst
+++ b/README.rst
@@ -34,11 +34,19 @@ Installation
 Auto-formatting with pre-commit
 -------------------------------
 
-This project is using `pre-commit <https://pre-commit.com/>`_.
+This project uses `pre-commit <https://pre-commit.com/>`_.
 
-#. Install the git pre-commit hooks on your clone::
+#. Install the required packages from :file:`requirements-test.txt`:
 
-    pre-commit install
+    .. code-block:: bash
+
+        pip install -r requirements-test.txt
+
+#. After installing the required packages, set up the git pre-commit hooks in your clone:
+
+    .. code-block:: bash
+
+        pre-commit install
 
 Every time you will try to commit, pre-commit will run checks on your files to make sure they follow our style standards and they aren't affected by some simple issues. If the checks fail, pre-commit won't let you commit.
 


### PR DESCRIPTION
Added instructions within the README file for setting up pre-commit, ensuring code formatting consistency before each commit.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
