### PR TITLE
[iam] Use lowercase when matching emails

### DIFF
--- a/bugbot/iam.py
+++ b/bugbot/iam.py
@@ -233,8 +233,8 @@ def update_bugzilla_emails(data: Dict[str, dict]) -> None:
     def handler(bz_user, data):
         if bz_user["id"] in users_by_bugzilla_id:
             person = users_by_bugzilla_id[bz_user["id"]]
-        elif bz_user["name"] in data:
-            person = data[bz_user["name"]]
+        elif bz_user["name"].lower() in data:
+            person = data[bz_user["name"].lower()]
         else:
             raise Exception(f"Can't find {bz_user['name']} in the data")
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Fix #2323 

This will prevent the mismatch when an email address on Bugzilla includes uppercase characters.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
