### PR TITLE
[file_crash_bug] Detect and highlight PHC crashes

### DIFF
--- a/bugbot/rules/file_crash_bug.py
+++ b/bugbot/rules/file_crash_bug.py
@@ -184,7 +184,7 @@ class FileCrashBug(BzCleaner):
             # [ ] Estimated future crash volume
 
             bug_data = {
-                "blocks": "bugbot-auto-crash",
+                "blocks": ["bugbot-auto-crash"],
                 "type": "defect",
                 "keywords": ["crash"],
                 "summary": title,
@@ -215,6 +215,9 @@ class FileCrashBug(BzCleaner):
                     }
                 ]
                 bug_data["cc"].append(signature.regressed_by_author["name"])
+
+            if signature.is_potential_phc_crash:
+                bug_data["blocks"].append("PHC")
 
             if signature.is_potential_security_crash:
                 bug_data["groups"] = ["core-security"]

--- a/templates/file_crash_bug_description.md.jinja
+++ b/templates/file_crash_bug_description.md.jinja
@@ -59,6 +59,14 @@ all crashes happened on or near an allocator poison value
 {{ signature.num_near_allocator_crashes }} out of {{ signature.num_crashes }} crashes happened on or near an allocator poison value
 {%- endif %}
 {%- endif %}
+{% if signature.is_potential_phc_crash -%}
+- **Is PHC crash:** {{ "Yes - " if signature.is_potential_phc_crash else "No" }}
+{%- if signature.is_phc_crash -%}
+all crashes have PHC allocation stack trace
+{%- elif signature.is_potential_phc_crash -%}
+{{ signature.num_phc_crashes }} out of {{ signature.num_crashes }} crashes have PHC allocation stack trace
+{%- endif %}
+{%- endif %}
 
 
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Resolves #2307 

This PR implements the following:
- Detect PHC crashes
- File them as security bugs
- Since they are security, a bug will be filed even when the crash volume is small
- The bug description will highlight whether the crash is related to PHC
- The filed bugs will block the [PHC meta bug](https://bugzilla.mozilla.org/show_bug.cgi?id=PHC)

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [x] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
