### PR TITLE
Don't ask for regression range on bugs with Has STR set to true if the reporter has a Mozilla email

### DIFF
--- a/bugbot/rules/has_str_no_range.py
+++ b/bugbot/rules/has_str_no_range.py
@@ -109,7 +109,7 @@ class HasSTRNoRange(BzCleaner):
             "n6": 1,
             "f6": "reporter",
             "o6": "regexp",
-            "v6": r"^.*@softvision\.(ro|com)$",
+            "v6": r"^.*@mozilla\.com$",
             "f7": "bug_type",
             "o7": "equals",
             "v7": "defect",


### PR DESCRIPTION
Fixes #2338

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
