### PR TITLE
Drop workaround related to missing uplift approval flags

### DIFF
--- a/bugbot/rules/uplift_beta.py
+++ b/bugbot/rules/uplift_beta.py
@@ -37,17 +37,6 @@ class UpliftBeta(BzCleaner):
         return ["id", "summary", "assignee"]
 
     def handle_bug(self, bug, data):
-        # XXX: This is a temporary workaround, should be dropped after
-        # fixing https://github.com/mozilla/bugbot/issues/1953
-        if self._has_patch_after_closed(bug):
-            from bugbot import logger
-
-            logger.error(
-                "Bug %s has a patch after being closed without an uplift approval flag. This could be a sign that Bug 1825961 is still not fixed.",
-                bug["id"],
-            )
-            return
-
         bugid = str(bug["id"])
 
         assignee = bug.get("assigned_to", "")
@@ -136,21 +125,6 @@ class UpliftBeta(BzCleaner):
         }
 
         return params
-
-    def _has_patch_after_closed(self, bug):
-        patches = [
-            attachment["creation_time"]
-            for attachment in bug["attachments"]
-            if attachment["content_type"] == "text/x-phabricator-request"
-            and not attachment["is_obsolete"]
-        ]
-        if len(patches) == 0:
-            return False
-
-        latest_patch_at = max(patches)
-        resolved_at = bug["cf_last_resolved"]
-
-        return latest_patch_at > resolved_at
 
     def get_bugs(self, date="today", bug_ids=[]):
         bugs = super(UpliftBeta, self).get_bugs(date=date, bug_ids=bug_ids)

--- a/scripts/cron_run_weekdays.sh
+++ b/scripts/cron_run_weekdays.sh
@@ -151,8 +151,7 @@ python -m bugbot.rules.inactive_ni_pending --production
 python -m bugbot.rules.crash_signature_confirm --production
 
 # Bugs with patches after being closed
-# Disabled temporarily until fixing https://github.com/mozilla/bugbot/issues/1953
-# python -m bugbot.rules.patch_closed_bug --production
+python -m bugbot.rules.patch_closed_bug --production
 
 # Confirm bugs with affected flags
 python -m bugbot.rules.affected_flag_confirm --production


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

The workarounds were implemented to mitigate [bug 1825961](https://bugzilla.mozilla.org/show_bug.cgi?id=1825961).

This PR will close #1953. Also, it will mitigate #2275 for the `uplift_beta` rule since we are dropping the impacted code. However, now we are enabling `patch_closed_bug`, it will be impacted by #2275 (the tool could fail).



## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
