### PR TITLE
Change 'Search and New Tab' name to 'Search Next Generation'

### DIFF
--- a/configs/team_managers.json
+++ b/configs/team_managers.json
@@ -19,7 +19,7 @@
   "DevTools": "Jan Odvarko",
   "Accessibility": "Frank Griffith Jr.",
   "Frontend": "Philip Luk",
-  "Search and New Tab": "Chris Bellini",
+  "Search Next Generation": "Chris Bellini",
   "Privacy Engineering": "Dan Mehic",
   "Credential Management": "Sergey Galich",
   "RelEng": "Johan Lorenzo",


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1889160

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
