### PR TITLE
Autoclear needinfo on expiring variant when closing its bug

### DIFF
--- a/bugbot/rules/variant_expiration.py
+++ b/bugbot/rules/variant_expiration.py
@@ -306,7 +306,7 @@ class VariantExpiration(BzCleaner, Nag):
                 "flags": [
                     {
                         "name": "needinfo",
-                        "status": "-",
+                        "status": "X",
                     }
                 ],
             }
@@ -318,6 +318,12 @@ class VariantExpiration(BzCleaner, Nag):
                 "comment": {
                     "body": f"The variant expiration date got extended to {new_date}",
                 },
+                "flags": [
+                    {
+                        "name": "needinfo",
+                        "status": "X",
+                    }
+                ],
             }
         elif action == ExpirationAction.NEEDINFO_TRIAGER:
             self.ni_extra[bugid] = {
@@ -340,7 +346,7 @@ class VariantExpiration(BzCleaner, Nag):
                 self.autofix_changes[bugid] = {
                     "comment": {
                         "body": EXPIRED_VARIANT_COMMENT,
-                    },
+                    }
                 }
 
         return bug

--- a/bugbot/rules/variant_expiration.py
+++ b/bugbot/rules/variant_expiration.py
@@ -306,8 +306,7 @@ class VariantExpiration(BzCleaner, Nag):
                 "flags": [
                     {
                         "name": "needinfo",
-                        "requestee": "",
-                        "status": "",
+                        "status": "-",
                     }
                 ],
             }

--- a/bugbot/rules/variant_expiration.py
+++ b/bugbot/rules/variant_expiration.py
@@ -303,6 +303,13 @@ class VariantExpiration(BzCleaner, Nag):
                 "comment": {
                     "body": f"The variant has been removed from the [variants.yml]({VARIANTS_SEARCHFOX_URL}) file."
                 },
+                "flags": [
+                    {
+                        "name": "needinfo",
+                        "requestee": bug["triage_owner"],
+                        "status": "X",
+                    }
+                ],
             }
         elif action == ExpirationAction.CLOSE_EXTENDED:
             new_date = self.variants[variant_name]["expiration"].strftime("%Y-%m-%d")

--- a/bugbot/rules/variant_expiration.py
+++ b/bugbot/rules/variant_expiration.py
@@ -306,8 +306,8 @@ class VariantExpiration(BzCleaner, Nag):
                 "flags": [
                     {
                         "name": "needinfo",
-                        "requestee": bug["triage_owner"],
-                        "status": "X",
+                        "requestee": "",
+                        "status": "",
                     }
                 ],
             }


### PR DESCRIPTION
Addressing #2183.

When a bug is closed due to an expiring variant, the `needinfo` flag is cleared (status set to `X`).

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
