### PR TITLE
Use the new Fenix components model to move bugs out of Fenix:General

### DIFF
--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 from libmozdata.bugzilla import Bugzilla
 
 from bugbot import logger

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -101,8 +101,23 @@ class Component(BzCleaner):
             fenix_general_classification = get_bug_ids_classification(
                 "fenixcomponent", fenix_general_bug_ids
             )
+
+            confidence_threshold = self.get_config("confidence_threshold")
+            general_confidence_threshold = self.get_config(
+                "general_confidence_threshold"
+            )
+
             for bug_id, data in fenix_general_classification.items():
-                bugs[bug_id] = data
+                original_data = bugs[bug_id]
+                original_confidence = original_data["prob"][original_data["index"]]
+                new_confidence = data["prob"][data["index"]]
+
+                # If the original confidence for Fenix::General met the threshold and the new classification does not, keep the old classification.
+                if not (
+                    new_confidence < confidence_threshold
+                    and original_confidence > general_confidence_threshold
+                ):
+                    bugs[bug_id] = data
 
         results = {}
 

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -109,6 +109,7 @@ class Component(BzCleaner):
 
                 # Only reclassify if the new confidence meets the Fenix component confidence threshold
                 if new_confidence > fenix_confidence_threshold:
+                    data["class"] = f"Fenix::{data['class']}"
                     bugs[bug_id] = data
 
         results = {}

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -102,9 +102,7 @@ class Component(BzCleaner):
                 "fenixcomponent", fenix_general_bug_ids
             )
 
-            fenix_confidence_threshold = self.get_config(
-                name="component", entry="fenix_confidence_threshold"
-            )
+            fenix_confidence_threshold = self.get_config("fenix_confidence_threshold")
 
             for bug_id, data in fenix_general_classification.items():
                 new_confidence = data["prob"][data["index"]]
@@ -130,15 +128,17 @@ class Component(BzCleaner):
             prob = bug_data["prob"]
             index = bug_data["index"]
             suggestion = bug_data["class"]
-            conflated_components_mapping = bug_data["extra_data"][
-                "conflated_components_mapping"
-            ]
+
+            conflated_components_mapping = bug_data["extra_data"].get(
+                "conflated_components_mapping", {}
+            )
 
             # Skip product-only suggestions that are not useful.
             if "::" not in suggestion and bug["product"] == suggestion:
                 continue
 
-            suggestion = conflated_components_mapping.get(suggestion, suggestion)
+            if "Fenix" not in suggestion:
+                suggestion = conflated_components_mapping.get(suggestion, suggestion)
 
             if "::" not in suggestion:
                 logger.error(

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -93,7 +93,7 @@ class Component(BzCleaner):
         fenix_general_bug_ids = [
             bug_id
             for bug_id, bug_data in bugs.items()
-            if "class" in bug_data and bug_data["class"] == "Fenix::General"
+            if bug_data.get("class") == "Fenix::General"
         ]
 
         # Reclassify the Fenix::General bugs using the fenixcomponent model
@@ -101,8 +101,8 @@ class Component(BzCleaner):
             fenix_general_classification = get_bug_ids_classification(
                 "fenixcomponent", fenix_general_bug_ids
             )
-            for bug_id in fenix_general_classification:
-                bugs[bug_id] = fenix_general_classification[bug_id]
+            for bug_id, data in fenix_general_classification.items():
+                bugs[bug_id] = data
 
         results = {}
 

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -102,21 +102,15 @@ class Component(BzCleaner):
                 "fenixcomponent", fenix_general_bug_ids
             )
 
-            confidence_threshold = self.get_config("confidence_threshold")
-            general_confidence_threshold = self.get_config(
-                "general_confidence_threshold"
+            fenix_confidence_threshold = self.get_config(
+                name="component", entry="fenix_confidence_threshold"
             )
 
             for bug_id, data in fenix_general_classification.items():
-                original_data = bugs[bug_id]
-                original_confidence = original_data["prob"][original_data["index"]]
                 new_confidence = data["prob"][data["index"]]
 
-                # If the original confidence for Fenix::General met the threshold and the new classification does not, keep the old classification.
-                if not (
-                    new_confidence < confidence_threshold
-                    and original_confidence > general_confidence_threshold
-                ):
+                # Only reclassify if the new confidence meets the Fenix component confidence threshold
+                if new_confidence > fenix_confidence_threshold:
                     bugs[bug_id] = data
 
         results = {}

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -82,14 +82,11 @@ class Component(BzCleaner):
         }
 
     def get_bugs(self, date="today", bug_ids=[]):
-        def select_threshold(bug_data):
-            if bug_data["class"] == "Fenix" or bug_data["class"] == "General":
-                return self.general_confidence_threshold
-            else:
-                return self.component_confidence_threshold
-
         def meets_threshold(bug_data):
-            threshold = select_threshold(bug_data)
+            if bug_data["class"] == "Fenix" or bug_data["class"] == "General":
+                threshold = self.general_confidence_threshold
+            else:
+                threshold = self.component_confidence_threshold
             return bug_data["prob"][bug_data["index"]] >= threshold
 
         # Retrieve the bugs with the fields defined in get_bz_params

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -93,8 +93,7 @@ class Component(BzCleaner):
         fenix_general_bug_ids = [
             bug_id
             for bug_id, bug_data in bugs.items()
-            if bugs[bug_id]["product"] == "Fenix"
-            and bugs[bug_id]["component"] == "General"
+            if "class" in bug_data and bug_data["class"] == "Fenix::General"
         ]
 
         # Reclassify the Fenix:General bugs using the fenixcomponent model

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -77,96 +77,6 @@ class Component(BzCleaner):
         }
 
     def get_bugs(self, date="today", bug_ids=[]):
-        def process_bugs(bugs, raw_bugs, results, reclassify_fenix):
-            for bug_id in sorted(bugs.keys()):
-                bug_data = bugs[bug_id]
-
-                if not bug_data.get("available", True):
-                    # The bug was not available, it was either removed or is a
-                    # security bug
-                    continue
-
-                if not {"prob", "index", "class", "extra_data"}.issubset(
-                    bug_data.keys()
-                ):
-                    raise Exception(f"Invalid bug response {bug_id}: {bug_data!r}")
-
-                bug = raw_bugs[bug_id]
-                prob = bug_data["prob"]
-                index = bug_data["index"]
-                suggestion = bug_data["class"]
-                conflated_components_mapping = bug_data["extra_data"][
-                    "conflated_components_mapping"
-                ]
-
-                # Skip product-only suggestions that are not useful.
-                if "::" not in suggestion and bug["product"] == suggestion:
-                    continue
-
-                suggestion = conflated_components_mapping.get(suggestion, suggestion)
-
-                if "::" not in suggestion:
-                    logger.error(
-                        f"There is something wrong with this component suggestion! {suggestion}"
-                    )
-                    continue
-
-                i = suggestion.index("::")
-                suggested_product = suggestion[:i]
-                suggested_component = suggestion[i + 2 :]
-
-                # When moving bugs out of the 'General' component, we don't want to change the product (unless it is Firefox).
-                if bug["component"] == "General" and bug["product"] not in {
-                    suggested_product,
-                    "Firefox",
-                }:
-                    continue
-
-                # Don't move bugs from Firefox::General to Core::Internationalization.
-                if (
-                    bug["product"] == "Firefox"
-                    and bug["component"] == "General"
-                    and suggested_product == "Core"
-                    and suggested_component == "Internationalization"
-                ):
-                    continue
-
-                result = {
-                    "id": bug_id,
-                    "summary": bug["summary"],
-                    "component": suggestion,
-                    "confidence": nice_round(prob[index]),
-                    "autofixed": False,
-                }
-
-                # In daily mode, we send an email with all results.
-                if self.frequency == "daily":
-                    results[bug_id] = result
-
-                confidence_threshold_conf = (
-                    "confidence_threshold"
-                    if bug["component"] != "General"
-                    else "general_confidence_threshold"
-                )
-
-                if prob[index] >= self.get_config(confidence_threshold_conf):
-                    self.autofix_component[bug_id] = {
-                        "product": suggested_product,
-                        "component": suggested_component,
-                    }
-
-                    result["autofixed"] = True
-
-                    # In hourly mode, we send an email with only the bugs we acted upon.
-                    if self.frequency == "hourly":
-                        results[bug_id] = result
-
-                # Collect bugs that were classified as Fenix::General
-                if bug["product"] == "Fenix" and bug["component"] == "General":
-                    fenix_general_bug_ids.append(bug_id)
-
-            return fenix_general_bug_ids
-
         # Retrieve the bugs with the fields defined in get_bz_params
         raw_bugs = super().get_bugs(date=date, bug_ids=bug_ids, chunk_size=7000)
 
@@ -179,20 +89,104 @@ class Component(BzCleaner):
         # Classify those bugs
         bugs = get_bug_ids_classification("component", bug_ids)
 
-        results = {}
+        # Collect bugs classified as Fenix:General
+        fenix_general_bug_ids = [
+            bug_id
+            for bug_id, bug_data in bugs.items()
+            if bugs[bug_id]["product"] == "Fenix"
+            and bugs[bug_id]["component"] == "General"
+        ]
 
-        # List to store IDs of bugs classified as Fenix::General
-        fenix_general_bug_ids = []
-
-        fenix_general_bug_ids = process_bugs(
-            bugs, raw_bugs, results, fenix_general_bug_ids
-        )
-
+        # Reclassify the Fenix:General bugs using the fenixcomponent model
         if fenix_general_bug_ids:
-            fenix_bugs = get_bug_ids_classification(
+            fenix_general_classification = get_bug_ids_classification(
                 "fenixcomponent", fenix_general_bug_ids
             )
-            process_bugs(fenix_bugs, raw_bugs, results)
+            for bug_id in fenix_general_classification:
+                bugs[bug_id] = fenix_general_classification[bug_id]
+
+        results = {}
+
+        for bug_id in sorted(bugs.keys()):
+            bug_data = bugs[bug_id]
+
+            if not bug_data.get("available", True):
+                # The bug was not available, it was either removed or is a
+                # security bug
+                continue
+
+            if not {"prob", "index", "class", "extra_data"}.issubset(bug_data.keys()):
+                raise Exception(f"Invalid bug response {bug_id}: {bug_data!r}")
+
+            bug = raw_bugs[bug_id]
+            prob = bug_data["prob"]
+            index = bug_data["index"]
+            suggestion = bug_data["class"]
+            conflated_components_mapping = bug_data["extra_data"][
+                "conflated_components_mapping"
+            ]
+
+            # Skip product-only suggestions that are not useful.
+            if "::" not in suggestion and bug["product"] == suggestion:
+                continue
+
+            suggestion = conflated_components_mapping.get(suggestion, suggestion)
+
+            if "::" not in suggestion:
+                logger.error(
+                    f"There is something wrong with this component suggestion! {suggestion}"
+                )
+                continue
+
+            i = suggestion.index("::")
+            suggested_product = suggestion[:i]
+            suggested_component = suggestion[i + 2 :]
+
+            # When moving bugs out of the 'General' component, we don't want to change the product (unless it is Firefox).
+            if bug["component"] == "General" and bug["product"] not in {
+                suggested_product,
+                "Firefox",
+            }:
+                continue
+
+            # Don't move bugs from Firefox::General to Core::Internationalization.
+            if (
+                bug["product"] == "Firefox"
+                and bug["component"] == "General"
+                and suggested_product == "Core"
+                and suggested_component == "Internationalization"
+            ):
+                continue
+
+            result = {
+                "id": bug_id,
+                "summary": bug["summary"],
+                "component": suggestion,
+                "confidence": nice_round(prob[index]),
+                "autofixed": False,
+            }
+
+            # In daily mode, we send an email with all results.
+            if self.frequency == "daily":
+                results[bug_id] = result
+
+            confidence_threshold_conf = (
+                "confidence_threshold"
+                if bug["component"] != "General"
+                else "general_confidence_threshold"
+            )
+
+            if prob[index] >= self.get_config(confidence_threshold_conf):
+                self.autofix_component[bug_id] = {
+                    "product": suggested_product,
+                    "component": suggested_component,
+                }
+
+                result["autofixed"] = True
+
+                # In hourly mode, we send an email with only the bugs we acted upon.
+                if self.frequency == "hourly":
+                    results[bug_id] = result
 
         # Don't move bugs back into components they were moved out of.
         # TODO: Use the component suggestion from the service with the second highest confidence instead.

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -93,7 +93,7 @@ class Component(BzCleaner):
         fenix_general_bug_ids = [
             bug_id
             for bug_id, bug_data in bugs.items()
-            if bug_data.get("class") == "Fenix::General"
+            if bug_data.get("class") == "Fenix"
         ]
 
         # Reclassify the Fenix::General bugs using the fenixcomponent model

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -89,14 +89,14 @@ class Component(BzCleaner):
         # Classify those bugs
         bugs = get_bug_ids_classification("component", bug_ids)
 
-        # Collect bugs classified as Fenix:General
+        # Collect bugs classified as Fenix::General
         fenix_general_bug_ids = [
             bug_id
             for bug_id, bug_data in bugs.items()
             if "class" in bug_data and bug_data["class"] == "Fenix::General"
         ]
 
-        # Reclassify the Fenix:General bugs using the fenixcomponent model
+        # Reclassify the Fenix::General bugs using the fenixcomponent model
         if fenix_general_bug_ids:
             fenix_general_classification = get_bug_ids_classification(
                 "fenixcomponent", fenix_general_bug_ids

--- a/configs/rules.json
+++ b/configs/rules.json
@@ -349,6 +349,7 @@
   },
   "component": {
     "confidence_threshold": 0.35,
+    "fenix_confidence_threshold": 0.6,
     "general_confidence_threshold": 0.8,
     "days_lookup": 365,
     "max_days_in_cache": 7,


### PR DESCRIPTION
Resolves #2398.

Intended to use the Fenix-specific component classifier model from [mozilla/bugbug#4172](https://github.com/mozilla/bugbug/issues/4172) to move bugs that already exist in `Fenix:General` or have been classified in `Fenix:General` by the general `component` model to the other Fenix components.

**NOTE:** Dependent on [mozilla/bugbug#4172](https://github.com/mozilla/bugbug/issues/4172) to be merged first to use the Fenix-specific component classifier model.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [x] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
