### PR TITLE
Autoclear needinfo top crash

### DIFF
--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -124,11 +124,12 @@ class CrashSmallVolume(BzCleaner):
             "signatures": signatures,
         }
 
-        data[bugid]["needinfo_ids"] = []
-
         # Add needinfo IDs only if the keyword to remove is "topcrash"
-        if "topcrash" in keywords_to_remove:
-            data[bugid]["needinfo_ids"] = self.get_needinfo_topcrash_ids(bug)
+        data[bugid]["needinfo_ids"] = (
+            self.get_needinfo_topcrash_ids(bug)
+            if "topcrash" in keywords_to_remove
+            else []
+        )
 
         return bug
 

--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -122,14 +122,10 @@ class CrashSmallVolume(BzCleaner):
             ),
             "keywords_to_remove": keywords_to_remove,
             "signatures": signatures,
-        }
-
-        # Add needinfo IDs only if the keyword to remove is "topcrash"
-        data[bugid]["needinfo_ids"] = (
-            self.get_needinfo_topcrash_ids(bug)
+            "needinfo_ids": self.get_needinfo_topcrash_ids(bug)
             if "topcrash" in keywords_to_remove
-            else []
-        )
+            else [],
+        }
 
         return bug
 
@@ -188,15 +184,13 @@ class CrashSmallVolume(BzCleaner):
                 )
                 autofix["keywords"] = {"remove": list(bug["keywords_to_remove"])}
 
-                # Clear needinfo flags requested by BugBot relating to increasing severity
-                if "topcrash" in bug["keywords_to_remove"]:
-                    autofix["flags"] = [
-                        {
-                            "id": flag_id,
-                            "status": "X",
-                        }
-                        for flag_id in bug.get("needinfo_ids", [])
-                    ]
+                autofix["flags"] = [
+                    {
+                        "id": flag_id,
+                        "status": "X",
+                    }
+                    for flag_id in bug.get("needinfo_ids", [])
+                ]
 
             if not bug["ignore_severity"] and all(
                 signature in low_volume_signatures for signature in bug["signatures"]

--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -183,7 +183,13 @@ class CrashSmallVolume(BzCleaner):
 
                 # TODO: create method to identify needinfo flags requested by the bot and are specifically for increasing severity
                 if "topcrash" in bug["keywords_to_remove"]:
-                    autofix["flags"] = {"id": 0, "status": "X"}
+                    autofix["flags"] = [
+                        {
+                            "id": flag_id,
+                            "status": "X",
+                        }
+                        for flag_id in self.get_needinfo_topcrash_ids(bug)
+                    ]
 
             if not bug["ignore_severity"] and all(
                 signature in low_volume_signatures for signature in bug["signatures"]
@@ -205,6 +211,14 @@ class CrashSmallVolume(BzCleaner):
                     "body": "\n\n".join(reasons),
                 }
                 self.autofix_changes[bugid] = autofix
+
+    def get_needinfo_topcrash_ids(self, bug: dict) -> list[str]:
+        """Get the IDs of the needinfo flags requested by the bot"""
+        return [
+            flag["id"]
+            for flag in bug.get("flags", [])
+            if flag["name"] == "needinfo" and flag["requestee"] == History.BOT
+        ]
 
     @staticmethod
     def _has_severity_downgrade_comment(bug):

--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -122,9 +122,11 @@ class CrashSmallVolume(BzCleaner):
             ),
             "keywords_to_remove": keywords_to_remove,
             "signatures": signatures,
-            "flags": bug.get("flags", []),
-            "comments": bug.get("comments", []),
         }
+
+        # Add needinfo IDs only if the keyword to remove is "topcrash"
+        if "topcrash" in keywords_to_remove:
+            data[bugid]["needinfo_ids"] = self.get_needinfo_topcrash_ids(bug)
 
         return bug
 
@@ -190,7 +192,7 @@ class CrashSmallVolume(BzCleaner):
                             "id": flag_id,
                             "status": "X",
                         }
-                        for flag_id in self.get_needinfo_topcrash_ids(bug)
+                        for flag_id in bug.get("needinfo_ids", [])
                     ]
 
             if not bug["ignore_severity"] and all(

--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -124,6 +124,8 @@ class CrashSmallVolume(BzCleaner):
             "signatures": signatures,
         }
 
+        data[bugid]["needinfo_ids"] = []
+
         # Add needinfo IDs only if the keyword to remove is "topcrash"
         if "topcrash" in keywords_to_remove:
             data[bugid]["needinfo_ids"] = self.get_needinfo_topcrash_ids(bug)

--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -183,15 +183,13 @@ class CrashSmallVolume(BzCleaner):
 
                 # Clear needinfo flags requested by BugBot relating to increasing severity
                 if "topcrash" in bug["keywords_to_remove"]:
-                    flag_id = self.get_needinfo_topcrash_ids
-                    if flag_id is not None:
-                        autofix["flags"] = [
-                            {
-                                "id": flag_id,
-                                "status": "X",
-                            }
-                            for flag_id in self.get_needinfo_topcrash_ids(bug)
-                        ]
+                    autofix["flags"] = [
+                        {
+                            "id": flag_id,
+                            "status": "X",
+                        }
+                        for flag_id in self.get_needinfo_topcrash_ids(bug)
+                    ]
 
             if not bug["ignore_severity"] and all(
                 signature in low_volume_signatures for signature in bug["signatures"]

--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -181,6 +181,10 @@ class CrashSmallVolume(BzCleaner):
                 )
                 autofix["keywords"] = {"remove": list(bug["keywords_to_remove"])}
 
+                # TODO: create method to identify needinfo flags requested by the bot and are specifically for increasing severity
+                if "topcrash" in bug["keywords_to_remove"]:
+                    autofix["flags"] = {"id": 0, "status": "X"}
+
             if not bug["ignore_severity"] and all(
                 signature in low_volume_signatures for signature in bug["signatures"]
             ):

--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -220,9 +220,6 @@ class CrashSmallVolume(BzCleaner):
             if flag["name"] == "needinfo" and flag["requestee"] == History.BOT
         ]
 
-        if not needinfo_flags:
-            return []
-
         needinfo_comment = (
             "could you consider increasing the severity of this top-crash bug?"
         )
@@ -233,9 +230,6 @@ class CrashSmallVolume(BzCleaner):
             if comment["creator"] == History.BOT
             and needinfo_comment in comment["raw_text"]
         ]
-
-        if not severity_comment_times:
-            return []
 
         return [
             flag["id"]

--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -122,9 +122,11 @@ class CrashSmallVolume(BzCleaner):
             ),
             "keywords_to_remove": keywords_to_remove,
             "signatures": signatures,
-            "needinfo_ids": self.get_needinfo_topcrash_ids(bug)
-            if "topcrash" in keywords_to_remove
-            else [],
+            "needinfo_ids": (
+                self.get_needinfo_topcrash_ids(bug)
+                if "topcrash" in keywords_to_remove
+                else []
+            ),
         }
 
         return bug
@@ -183,7 +185,6 @@ class CrashSmallVolume(BzCleaner):
                     )
                 )
                 autofix["keywords"] = {"remove": list(bug["keywords_to_remove"])}
-
                 autofix["flags"] = [
                     {
                         "id": flag_id,

--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -122,6 +122,8 @@ class CrashSmallVolume(BzCleaner):
             ),
             "keywords_to_remove": keywords_to_remove,
             "signatures": signatures,
+            "flags": bug.get("flags", []),
+            "comments": bug.get("comments", []),
         }
 
         return bug

--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -122,7 +122,7 @@ class CrashSmallVolume(BzCleaner):
             ),
             "keywords_to_remove": keywords_to_remove,
             "signatures": signatures,
-            "needinfo_ids": (
+            "needinfos_to_remove": (
                 self.get_needinfo_topcrash_ids(bug)
                 if "topcrash" in keywords_to_remove
                 else []
@@ -190,7 +190,7 @@ class CrashSmallVolume(BzCleaner):
                         "id": flag_id,
                         "status": "X",
                     }
-                    for flag_id in bug.get("needinfo_ids", [])
+                    for flag_id in bug.get("needinfos_to_remove", [])
                 ]
 
             if not bug["ignore_severity"] and all(

--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -190,7 +190,7 @@ class CrashSmallVolume(BzCleaner):
                         "id": flag_id,
                         "status": "X",
                     }
-                    for flag_id in bug.get("needinfos_to_remove", [])
+                    for flag_id in bug["needinfos_to_remove"]
                 ]
 
             if not bug["ignore_severity"] and all(

--- a/bugbot/rules/crash_small_volume.py
+++ b/bugbot/rules/crash_small_volume.py
@@ -218,7 +218,7 @@ class CrashSmallVolume(BzCleaner):
         """Get the IDs of the needinfo flags requested by the bot regarding increasing the severity."""
         needinfo_flags = [
             flag
-            for flag in bug.get("flags", [])
+            for flag in bug["flags"]
             if flag["name"] == "needinfo" and flag["requestee"] == History.BOT
         ]
 
@@ -289,6 +289,7 @@ class CrashSmallVolume(BzCleaner):
             "comments.creator",
             "comments.creation_time",
             "history",
+            "flags",
         ]
         params = {
             "include_fields": fields,


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Resolves #1684.

Autoclears the `needinfo` flag to increase the severity of the bug when the `topcrash` keyword is dropped.
## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [x] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
