### PR TITLE
Exclude patches that depend on other patches

### DIFF
--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -200,12 +200,14 @@ class NotLanded(BzCleaner):
             ).group(1)
             try:
                 revision_data = self.phab.load_revision(rev_id=int(rev))
-                stack_graph = revision_data["fields"]["stackGraph"]
-                current_revision_phid = revision_data["phid"]
-                dependencies = stack_graph[current_revision_phid]
-                return bool(dependencies)
             except PhabricatorRevisionNotFoundException:
-                return False
+                # Return True, as we will skip any bugs that encountered this error
+                return True
+
+            stack_graph = revision_data["fields"]["stackGraph"]
+            current_revision_phid = revision_data["phid"]
+            dependencies = stack_graph[current_revision_phid]
+            return bool(dependencies)
 
         bugids = list(bugs.keys())
         data = {

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -217,7 +217,12 @@ class NotLanded(BzCleaner):
 
         bugids = list(bugs.keys())
         data = {
-            bugid: {"backout": False, "author": None, "count": 0, "dependencies": False}
+            bugid: {
+                "backout": False,
+                "author": None,
+                "count": 0,
+                "has_blocking_dependencies": False,
+            }
             for bugid in bugids
         }
 
@@ -254,7 +259,9 @@ class NotLanded(BzCleaner):
 
             if "phab" in res:
                 if res["phab"]:
-                    data[bugid]["dependencies"] = has_blocking_dependencies(attachment)
+                    data[bugid][
+                        "has_blocking_dependencies"
+                    ] = has_blocking_dependencies(attachment)
                     data[bugid]["reviewers_phid"] = res["reviewers_phid"]
                     data[bugid]["author"] = res["author"]
                     data[bugid]["count"] = res["count"]
@@ -274,7 +281,7 @@ class NotLanded(BzCleaner):
         data = {
             bugid: v
             for bugid, v in data.items()
-            if not v["backout"] and not v["dependencies"]
+            if not v["backout"] and not v["has_blocking_dependencies"]
         }
 
         return data

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -362,6 +362,13 @@ class NotLanded(BzCleaner):
             if not assignee:
                 continue
 
+            stack_graph = data.get("stackGraph", {})
+            current_revision_phid = data.get("phid")
+            dependencies = stack_graph.get(current_revision_phid, [])
+
+            if dependencies:
+                continue
+
             self.add_auto_ni(bugid, {"mail": assignee, "nickname": nickname})
 
             common = all_reviewers & data["reviewers_phid"]

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -125,6 +125,14 @@ class NotLanded(BzCleaner):
         if not reviewers:
             return False
 
+        # Check for dependencies in the stackGraph field
+        stack_graph = data["fields"].get("stackGraph", {})
+        current_revision_phid = data.get("phid")
+        dependencies = stack_graph.get(current_revision_phid, [])
+
+        if dependencies:
+            return None
+
         for reviewer in reviewers:
             if reviewer["status"] != "accepted":
                 return False

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -125,14 +125,6 @@ class NotLanded(BzCleaner):
         if not reviewers:
             return False
 
-        # Check for dependencies in the stackGraph field
-        stack_graph = data["fields"].get("stackGraph", {})
-        current_revision_phid = data.get("phid")
-        dependencies = stack_graph.get(current_revision_phid, [])
-
-        if dependencies:
-            return None
-
         for reviewer in reviewers:
             if reviewer["status"] != "accepted":
                 return False


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Resolves #1625.

Exclude patches that depend on other patches (in Phabricator) from nagging/setting needinfo when running the `not_landed.py` rule.
## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
