### PR TITLE
Remove logging error for missing triage owner for `Firefox::Untriaged`

### DIFF
--- a/bugbot/round_robin.py
+++ b/bugbot/round_robin.py
@@ -148,7 +148,7 @@ class RoundRobin(object):
             if utils.is_no_assignee(mail):
                 mail, nick = None, None
 
-            if mail is None:
+            if mail is None and pc != "Firefox::Untriaged":
                 logger.error("No triage owner for {}".format(pc))
 
             self.add_component_for_triager(pc, mail)


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Resolves #1982.

Currently an error is logged in `bugbot/round_robin.py` when a product-component pair do not have a triage owner. However, it is expected that `Firefox::Untriaged` has no assigned triage owner. Thus, if the product-component pair is `Firefox::Untriaged`, the error logging is avoided.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
