### PR TITLE
[not_landed] Prevent requesting needinfo for backed out patches

### DIFF
--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -167,12 +167,15 @@ class NotLanded(BzCleaner):
 
     def get_patch_data(self, bugs):
         """Get patch information in bugs"""
+        nightly_pat = Bugzilla.get_landing_patterns(channels=["nightly"])[0][0]
 
         def comment_handler(bug, bugid, data):
             # if a comment contains a backout: don't nag
             for comment in bug["comments"]:
                 comment = comment["text"].lower()
-                if "backed out" in comment or "backout" in comment:
+                if nightly_pat.match(comment) and (
+                    "backed out" in comment or "backout" in comment
+                ):
                     data[bugid]["backout"] = True
 
         def attachment_id_handler(attachments, bugid, data):

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -178,12 +178,6 @@ class NotLanded(BzCleaner):
                 ):
                     data[bugid]["backout"] = True
 
-                    # If the the bug has been backed out, we can mark it as "changes-planned" to prevent further nagging in the future
-                    if not self.dryrun:
-                        phid = data["phid"]
-                        transactions = [{"type": "status", "value": "changes-planned"}]
-                        self.phab.edit_revision(phid, transactions)
-
         def attachment_id_handler(attachments, bugid, data):
             for a in attachments:
                 if (

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -183,7 +183,6 @@ class NotLanded(BzCleaner):
 
                     if not self.dryrun:
                         transactions = [{"type": "status", "value": "changes-planned"}]
-
                         self.phab.edit_revision(phid, transactions)
 
         def attachment_id_handler(attachments, bugid, data):
@@ -360,9 +359,6 @@ class NotLanded(BzCleaner):
                 assignee, nickname = nicknames[bugid]
 
             if not assignee:
-                continue
-
-            if data.get("backout", False):
                 continue
 
             self.add_auto_ni(bugid, {"mail": assignee, "nickname": nickname})

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -168,12 +168,15 @@ class NotLanded(BzCleaner):
     def get_patch_data(self, bugs):
         """Get patch information in bugs"""
         nightly_pat = Bugzilla.get_landing_patterns(channels=["nightly"])[0][0]
+        autoland_pat = re.compile(
+            r"://hg.mozilla.org/integration/autoland/rev/([0-9a-f]+)"
+        )
 
         def comment_handler(bug, bugid, data):
             # if a comment contains a backout: don't nag
             for comment in bug["comments"]:
                 comment = comment["text"].lower()
-                if nightly_pat.match(comment) and (
+                if (nightly_pat.match(comment) or autoland_pat.search(comment)) and (
                     "backed out" in comment or "backout" in comment
                 ):
                     data[bugid]["backout"] = True

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -354,6 +354,9 @@ class NotLanded(BzCleaner):
             if not assignee:
                 continue
 
+            if data.get("backout", False):
+                continue
+
             self.add_auto_ni(bugid, {"mail": assignee, "nickname": nickname})
 
             common = all_reviewers & data["reviewers_phid"]

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -66,21 +66,6 @@ class NotLanded(BzCleaner):
 
         return bug
 
-    def update_revision_status(self, rev_id, status_type, value):
-        try:
-            self.phab.request(
-                "differential.revision.edit",
-                objectIdentifier=rev_id,
-                transactions=[{"type": status_type, "value": value}],
-            )
-            print(
-                f"Successfully updated revision {rev_id} with {status_type} to {value}"
-            )
-        except Exception as e:
-            print(
-                f"Failed to update revision {rev_id} with {status_type} to {value}: {e}"
-            )
-
     def filter_bugs(self, bugs):
         # We must remove bugs which have open dependencies (except meta bugs)
         # because devs may wait for those bugs to be fixed before their patch
@@ -259,12 +244,6 @@ class NotLanded(BzCleaner):
             commentdata=data,
             comment_include_fields=["text"],
         ).get_data().wait()
-
-        for bugid, v in data.items():
-            if data[bugid]["backout"]:
-                phab_url = base64.b64decode(attachment["data"]).decode("utf-8")
-                rev = PHAB_URL_PAT.search(phab_url).group(1)
-                self.update_revision_status(int(rev), "plan-changes", True)
 
         data = {bugid: v for bugid, v in data.items() if not v["backout"]}
 

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -178,10 +178,9 @@ class NotLanded(BzCleaner):
                 ):
                     data[bugid]["backout"] = True
 
-                    # Set the status of the Phabricator revision to be "Changes Planned"
-                    phid = data.get("phid")
-
+                    # If the the bug has been backed out, we can mark it as "changes-planned" to prevent further nagging in the future
                     if not self.dryrun:
+                        phid = data["phid"]
                         transactions = [{"type": "status", "value": "changes-planned"}]
                         self.phab.edit_revision(phid, transactions)
 

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -178,6 +178,14 @@ class NotLanded(BzCleaner):
                 ):
                     data[bugid]["backout"] = True
 
+                    # Set the status of the Phabricator revision to be "Changes Planned"
+                    phid = data.get("phid")
+
+                    if not self.dryrun:
+                        transactions = [{"type": "status", "value": "changes-planned"}]
+
+                        self.phab.edit_revision(phid, transactions)
+
         def attachment_id_handler(attachments, bugid, data):
             for a in attachments:
                 if (

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -66,6 +66,21 @@ class NotLanded(BzCleaner):
 
         return bug
 
+    def update_revision_status(self, rev_id, status_type, value):
+        try:
+            self.phab.request(
+                "differential.revision.edit",
+                objectIdentifier=rev_id,
+                transactions=[{"type": status_type, "value": value}],
+            )
+            print(
+                f"Successfully updated revision {rev_id} with {status_type} to {value}"
+            )
+        except Exception as e:
+            print(
+                f"Failed to update revision {rev_id} with {status_type} to {value}: {e}"
+            )
+
     def filter_bugs(self, bugs):
         # We must remove bugs which have open dependencies (except meta bugs)
         # because devs may wait for those bugs to be fixed before their patch
@@ -247,6 +262,13 @@ class NotLanded(BzCleaner):
             commentdata=data,
             comment_include_fields=["text"],
         ).get_data().wait()
+
+        for bugid, attachments in attachments_by_bug.items():
+            if bugid in data:
+                if data[bugid]["backout"]:
+                    phab_url = base64.b64decode(attachment["data"]).decode("utf-8")
+                    rev = PHAB_URL_PAT.search(phab_url).group(1)
+                    self.update_revision_status(int(rev), "plan-changes", True)
 
         data = {bugid: v for bugid, v in data.items() if not v["backout"]}
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Resolves #1673.

Prevents BugBot from requesting `needinfo` when a patch has been backed out. 

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [x] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
