### PR TITLE
Add rule to set webcompat:platform-bug keyword on KB entry blockers

### DIFF
--- a/bugbot/rules/webcompat_platform_without_keyword.py
+++ b/bugbot/rules/webcompat_platform_without_keyword.py
@@ -1,0 +1,71 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from libmozdata.bugzilla import Bugzilla
+
+from bugbot.bzcleaner import BzCleaner
+
+
+class WebcompatPlatformWithoutKeyword(BzCleaner):
+    normal_changes_max = 200
+
+    def description(self):
+        return "Core bugs blocking webcompat knowledge base entries without webcompat:platform-bug"
+
+    def filter_no_nag_keyword(self):
+        return False
+
+    def has_default_products(self):
+        return False
+
+    def handle_bug(self, bug, data):
+        data[bug["id"]] = {"depends_on": set(bug.get("depends_on", []))}
+        return bug
+
+    def get_core_bugs(self, bugs):
+        core_bugs = set()
+        for bug_data in bugs.values():
+            core_bugs |= bug_data.get("depends_on", set())
+
+        def bug_handler(bug, data):
+            if "webcompat:platform-bug" not in bug["keywords"]:
+                data[bug["id"]] = bug
+
+        core_bug_data = {}
+
+        Bugzilla(
+            bugids=list(core_bugs),
+            include_fields=["id", "summary", "keywords"],
+            bughandler=bug_handler,
+            bugdata=core_bug_data,
+        ).get_data().wait()
+
+        return core_bug_data
+
+    def get_autofix_change(self):
+        return {
+            "keywords": {"add": ["webcompat:platform-bug"]},
+        }
+
+    def get_bz_params(self, date):
+        fields = [
+            "id",
+            "depends_on",
+        ]
+        params = {
+            "include_fields": fields,
+            "product": "Web Compatibility",
+            "component": "Knowledge Base",
+        }
+
+        return params
+
+    def get_bugs(self, *args, **kwargs):
+        bugs = super().get_bugs(*args, **kwargs)
+        bugs = self.get_core_bugs(bugs)
+        return bugs
+
+
+if __name__ == "__main__":
+    WebcompatPlatformWithoutKeyword().run()

--- a/templates/webcompat_platform_without_keyword.html
+++ b/templates/webcompat_platform_without_keyword.html
@@ -1,0 +1,23 @@
+<p>
+    The following {{ plural('bug is', data, pword='bugs are') }} blocking web compatibility knowledge base entries, but don't have the webcompat:platform-bug keyword set:
+</p>
+<table {{ table_attrs }}>
+    <thead>
+        <tr>
+            <th>Bug</th>
+            <th>Summary</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for i, (bugid, summary) in enumerate(data) -%}
+            <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
+            {% endif -%}
+            >
+            <td>
+                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+            </td>
+            <td>{{ summary | e }}</td>
+        </tr>
+    {% endfor -%}
+</tbody>
+</table>


### PR DESCRIPTION
Core platform bugs which have known site breakage are those that:

* Have the webcompat:platform-bug keyword set OR
* Block a bug in the Web Compatibility :: Knowledge Base component

Because that's not easy to express as a single bugzilla query, add a rule to ensure that any bug defined by its relationship also has the keyword set, so that other users can simply use a keyword query to find all these bugs.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
