### PR TITLE
Removed code for triaging old bugs with no severity set

### DIFF
--- a/bugbot/rules/workflow/no_severity.py
+++ b/bugbot/rules/workflow/no_severity.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from datetime import datetime
 
 import numpy
 from libmozdata import utils as lmdutils
@@ -273,23 +272,6 @@ class NoSeverity(BzCleaner, Nag):
                     "f30": "CP",
                 }
             )
-
-        # TODO: the following code can be removed in 2024.
-        # https://github.com/mozilla/bugbot/issues/1596
-        # Almost 500 old bugs have no severity set. The intent of the following
-        # is to have them triaged in batches where every week we include more
-        # bugs. Once the list of old bugs are reduced, we could safely remove
-        # the following code.
-        passed_time = datetime.now() - datetime.fromisoformat("2023-06-09")
-        oldest_bug_months = 56 + passed_time.days
-        n = utils.get_last_field_num(params)
-        params.update(
-            {
-                f"f{n}": "creation_ts",
-                f"o{n}": "greaterthan",
-                f"v{n}": f"-{oldest_bug_months}m",
-            }
-        )
 
         return params
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Resolves #1596.

The temporary code added to batch triage old bugs with no severity set is no longer needed as we are past the designated removal date. This code was responsible for incrementally including older bugs in triage batches.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
