### PR TITLE
[inactive_ni_pending] Consider new Bugzilla users to be inactive/absent in a shorter period of time

### DIFF
--- a/bugbot/bzcleaner.py
+++ b/bugbot/bzcleaner.py
@@ -8,7 +8,7 @@ import os
 import sys
 import time
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, List
 
 from dateutil.relativedelta import relativedelta
@@ -757,7 +757,9 @@ class BzCleaner(object):
         """Send the email"""
         if date:
             date = lmdutils.get_date(date)
+            date = (datetime.now() - timedelta(days=2)).strftime("%Y-%m-%d %H:%M:%S%z")
             d = lmdutils.get_date_ymd(date)
+            # print(d)
             if isinstance(self, Nag):
                 self.nag_date: datetime = d
 

--- a/bugbot/bzcleaner.py
+++ b/bugbot/bzcleaner.py
@@ -8,7 +8,7 @@ import os
 import sys
 import time
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Dict, List
 
 from dateutil.relativedelta import relativedelta
@@ -127,7 +127,7 @@ class BzCleaner(object):
         for day in days:
             if week[day] == weekday:
                 return True
-        return False
+        return True
 
     def has_enough_data(self):
         """Check if the rule has enough data to run"""
@@ -757,9 +757,7 @@ class BzCleaner(object):
         """Send the email"""
         if date:
             date = lmdutils.get_date(date)
-            date = (datetime.now() - timedelta(days=2)).strftime("%Y-%m-%d %H:%M:%S%z")
             d = lmdutils.get_date_ymd(date)
-            # print(d)
             if isinstance(self, Nag):
                 self.nag_date: datetime = d
 

--- a/bugbot/bzcleaner.py
+++ b/bugbot/bzcleaner.py
@@ -127,7 +127,7 @@ class BzCleaner(object):
         for day in days:
             if week[day] == weekday:
                 return True
-        return True
+        return False
 
     def has_enough_data(self):
         """Check if the rule has enough data to run"""

--- a/bugbot/rules/inactive_ni_pending.py
+++ b/bugbot/rules/inactive_ni_pending.py
@@ -74,9 +74,7 @@ class InactiveNeedinfoPending(BzCleaner):
 
                 requestee_bugs[flag["requestee"]].append(bugid)
 
-        user_activity = UserActivity(
-            include_fields=["groups"], activity_weeks_count=4, absent_weeks_count=4
-        )
+        user_activity = UserActivity(include_fields=["groups"])
         needinfo_requestees = set(requestee_bugs.keys())
         triage_owners = {bug["triage_owner"] for bug in bugs.values()}
         inactive_users = user_activity.check_users(

--- a/bugbot/rules/inactive_ni_pending.py
+++ b/bugbot/rules/inactive_ni_pending.py
@@ -74,7 +74,9 @@ class InactiveNeedinfoPending(BzCleaner):
 
                 requestee_bugs[flag["requestee"]].append(bugid)
 
-        user_activity = UserActivity(include_fields=["groups"])
+        user_activity = UserActivity(
+            include_fields=["groups"], activity_weeks_count=4, absent_weeks_count=4
+        )
         needinfo_requestees = set(requestee_bugs.keys())
         triage_owners = {bug["triage_owner"] for bug in bugs.values()}
         inactive_users = user_activity.check_users(

--- a/bugbot/rules/inactive_ni_pending.py
+++ b/bugbot/rules/inactive_ni_pending.py
@@ -74,7 +74,7 @@ class InactiveNeedinfoPending(BzCleaner):
 
                 requestee_bugs[flag["requestee"]].append(bugid)
 
-        user_activity = UserActivity(include_fields=["groups"])
+        user_activity = UserActivity(include_fields=["groups", "creation_time"])
         needinfo_requestees = set(requestee_bugs.keys())
         triage_owners = {bug["triage_owner"] for bug in bugs.values()}
         inactive_users = user_activity.check_users(
@@ -101,7 +101,8 @@ class InactiveNeedinfoPending(BzCleaner):
                     "setter": flag["setter"],
                     "requestee": flag["requestee"],
                     "requestee_status": user_activity.get_string_status(
-                        inactive_users[flag["requestee"]]["status"]
+                        inactive_users[flag["requestee"]]["status"],
+                        inactive_users[flag["requestee"]]["creation_time"],
                     ),
                     "requestee_canconfirm": has_canconfirm_group(flag["requestee"]),
                 }

--- a/bugbot/user_activity.py
+++ b/bugbot/user_activity.py
@@ -176,6 +176,9 @@ class UserActivity:
             if not user["can_login"]:
                 return UserStatus.DISABLED
 
+            if user["creation_time"] > self.new_user_seen_limit:
+                return UserStatus.ACTIVE
+
             if (
                 user["last_seen_date"] is None
                 or user["last_seen_date"] < self.new_user_seen_limit
@@ -187,9 +190,6 @@ class UserActivity:
                 or user["last_activity_time"] < self.new_user_activity_limit
             ):
                 return UserStatus.INACTIVE
-
-            if user["creation_time"] > self.new_user_seen_limit:
-                return UserStatus.ACTIVE
 
             return UserStatus.ACTIVE
 

--- a/bugbot/user_activity.py
+++ b/bugbot/user_activity.py
@@ -90,7 +90,7 @@ class UserActivity:
         self.new_user_seen_limit = lmdutils.get_date(
             reference_date, self.new_user_weeks_count * 7
         )
-        self.new_user_limit = self.seen_limit = lmdutils.get_date(reference_date, 61)
+        self.new_user_limit = lmdutils.get_date(reference_date, 61)
 
     def _get_phab(self):
         if not self.phab:

--- a/bugbot/user_activity.py
+++ b/bugbot/user_activity.py
@@ -342,16 +342,22 @@ class UserActivity:
 
         return False
 
-    def get_string_status(self, status: UserStatus):
+    def get_string_status(self, status: UserStatus, user_creation_time: str):
         """Get a string representation of the user status."""
+
+        is_new_user = user_creation_time > self.new_user_limit
 
         if status == UserStatus.UNDEFINED:
             return "Not specified"
         if status == UserStatus.DISABLED:
             return "Account disabled"
         if status == UserStatus.INACTIVE:
+            if is_new_user:
+                return f"Inactive on Bugzilla in last {self.new_user_weeks_count} weeks (new user)"
             return f"Inactive on Bugzilla in last {self.activity_weeks_count} weeks"
         if status == UserStatus.ABSENT:
+            if is_new_user:
+                return f"Not seen on Bugzilla in last {self.new_user_weeks_count} weeks (new user)"
             return f"Not seen on Bugzilla in last {self.absent_weeks_count} weeks"
 
         return status.name

--- a/bugbot/user_activity.py
+++ b/bugbot/user_activity.py
@@ -90,6 +90,8 @@ class UserActivity:
         self.new_user_seen_limit = lmdutils.get_date(
             reference_date, self.new_user_weeks_count * 7
         )
+
+        # Bugzilla accounts younger than 61 days are considered new users
         self.new_user_limit = lmdutils.get_date(reference_date, 61)
 
     def _get_phab(self):

--- a/bugbot/user_activity.py
+++ b/bugbot/user_activity.py
@@ -82,7 +82,7 @@ class UserActivity:
         self.seen_limit = lmdutils.get_date(reference_date, self.absent_weeks_count * 7)
 
         self.new_user_activity_limit = lmdutils.get_date(
-            reference_date, self.new_user_weeks_count
+            reference_date, self.new_user_weeks_count * 7
         )
         self.new_user_activity_limit_ts = lmdutils.get_date_ymd(
             self.new_user_activity_limit

--- a/bugbot/user_activity.py
+++ b/bugbot/user_activity.py
@@ -36,6 +36,7 @@ class UserActivity:
         self,
         activity_weeks_count: int = 26,
         absent_weeks_count: int = 26,
+        new_user_weeks_count: int = 4,
         unavailable_max_days: int = 7,
         include_fields: list | None = None,
         phab: PhabricatorAPI | None = None,
@@ -50,6 +51,8 @@ class UserActivity:
                 to a bug before a user being considered as inactive.
             absent_weeks_count: the number of weeks since last loaded any page
                 from Bugzilla before a user being considered as inactive.
+            new_user_weeks_count: the number of weeks since last made a change
+                to a bug before a new user being considered as inactive.
             unavailable_max_days: a user will be considered inactive if they
                 have more days left to be available than `unavailable_max_days`.
             include_fields: the list of fields to include with the the Bugzilla
@@ -64,6 +67,7 @@ class UserActivity:
         """
         self.activity_weeks_count = activity_weeks_count
         self.absent_weeks_count = absent_weeks_count
+        self.new_user_weeks_count = new_user_weeks_count
         self.include_fields = include_fields or []
         self.people = people if people is not None else People.get_instance()
         self.phab = phab

--- a/bugbot/user_activity.py
+++ b/bugbot/user_activity.py
@@ -172,39 +172,25 @@ class UserActivity:
 
     def get_status_from_bz_user(self, user: dict) -> UserStatus:
         """Get the user status from a Bugzilla user object."""
-        if user["creation_time"] > self.new_user_limit:
-            if not user["can_login"]:
-                return UserStatus.DISABLED
+        is_new_user = user["creation_time"] > self.new_user_limit
 
-            if user["creation_time"] > self.new_user_seen_limit:
-                return UserStatus.ACTIVE
-
-            if (
-                user["last_seen_date"] is None
-                or user["last_seen_date"] < self.new_user_seen_limit
-            ):
-                return UserStatus.ABSENT
-
-            if (
-                user["last_activity_time"] is None
-                or user["last_activity_time"] < self.new_user_activity_limit
-            ):
-                return UserStatus.INACTIVE
-
-            return UserStatus.ACTIVE
+        seen_limit = self.seen_limit if not is_new_user else self.new_user_seen_limit
+        activity_limit = (
+            self.activity_limit if not is_new_user else self.new_user_activity_limit
+        )
 
         if not user["can_login"]:
             return UserStatus.DISABLED
 
-        if user["creation_time"] > self.seen_limit:
+        if user["creation_time"] > seen_limit:
             return UserStatus.ACTIVE
 
-        if user["last_seen_date"] is None or user["last_seen_date"] < self.seen_limit:
+        if user["last_seen_date"] is None or user["last_seen_date"] < seen_limit:
             return UserStatus.ABSENT
 
         if (
             user["last_activity_time"] is None
-            or user["last_activity_time"] < self.activity_limit
+            or user["last_activity_time"] < activity_limit
         ):
             return UserStatus.INACTIVE
 

--- a/bugbot/user_activity.py
+++ b/bugbot/user_activity.py
@@ -161,7 +161,7 @@ class UserActivity:
 
     def get_status_from_bz_user(self, user: dict) -> UserStatus:
         """Get the user status from a Bugzilla user object."""
-
+        print(f"User: {user}")
         if not user["can_login"]:
             return UserStatus.DISABLED
 
@@ -212,6 +212,7 @@ class UserActivity:
                 "last_activity_time",
                 "last_seen_date",
                 "creation_time",
+                "new",
             ]
             + self.include_fields,
         ).wait()

--- a/bugbot/user_activity.py
+++ b/bugbot/user_activity.py
@@ -173,6 +173,9 @@ class UserActivity:
     def get_status_from_bz_user(self, user: dict) -> UserStatus:
         """Get the user status from a Bugzilla user object."""
         if user["creation_time"] > self.new_user_limit:
+            if not user["can_login"]:
+                return UserStatus.DISABLED
+
             if (
                 user["last_seen_date"] is None
                 or user["last_seen_date"] < self.new_user_seen_limit
@@ -187,9 +190,6 @@ class UserActivity:
 
             if user["creation_time"] > self.new_user_seen_limit:
                 return UserStatus.ACTIVE
-
-            if not user["can_login"]:
-                return UserStatus.DISABLED
 
             return UserStatus.ACTIVE
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Resolves #1580.

Currently, the `inactive_ni_pending` rule considers a user to be inactive and/or absent after 26 weeks. This PR intends to consider new Bugzilla users to be inactive/absent after 4 weeks.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
