### PR TITLE
[not_landed] Prevent requesting needinfo for backed out patches

### DIFF
--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -167,14 +167,13 @@ class NotLanded(BzCleaner):
 
     def get_patch_data(self, bugs):
         """Get patch information in bugs"""
-        nightly_pat = Bugzilla.get_landing_patterns(channels=["nightly"])[0][0]
-        autoland_pat = Bugzilla.get_landing_patterns(channels=["autoland"])[0][0]
+        patterns = Bugzilla.get_landing_patterns(channels=["nightly", "autoland"])
 
         def comment_handler(bug, bugid, data):
             # if a comment contains a backout: don't nag
             for comment in bug["comments"]:
                 comment = comment["text"].lower()
-                if (nightly_pat.match(comment) or autoland_pat.match(comment)) and (
+                if any(pat[0].match(comment) for pat in patterns) and (
                     "backed out" in comment or "backout" in comment
                 ):
                     data[bugid]["backout"] = True

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -168,12 +168,13 @@ class NotLanded(BzCleaner):
     def get_patch_data(self, bugs):
         """Get patch information in bugs"""
         nightly_pat = Bugzilla.get_landing_patterns(channels=["nightly"])[0][0]
+        autoland_pat = Bugzilla.get_landing_patterns(channels=["autoland"])[0][0]
 
         def comment_handler(bug, bugid, data):
             # if a comment contains a backout: don't nag
             for comment in bug["comments"]:
                 comment = comment["text"].lower()
-                if nightly_pat.match(comment) and (
+                if (nightly_pat.match(comment) or autoland_pat.match(comment)) and (
                     "backed out" in comment or "backout" in comment
                 ):
                     data[bugid]["backout"] = True


### PR DESCRIPTION
Resolves https://github.com/mozilla/bugbot/issues/1673.

Prevents BugBot from requesting needinfo when a patch has been backed out.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
