### PR TITLE
Make webcompat platform bugs without keyword use BQ data

### DIFF
--- a/bugbot/rules/webcompat_platform_without_keyword.py
+++ b/bugbot/rules/webcompat_platform_without_keyword.py
@@ -46,8 +46,9 @@ class WebcompatPlatformWithoutKeyword(BzCleaner):
         client = bigquery.Client(project=project, credentials=credentials)
 
         query = f"""
-        SELECT core_bug FROM `{project}.{dataset}.prioritized_kb_entries` as kb_entries
-        JOIN `moz-fx-dev-dschubert-wckb.webcompat_knowledge_base.bugzilla_bugs` as bugzilla_bugs ON bugzilla_bugs.number = kb_entries.core_bug
+        SELECT core_bug 
+        FROM `{project}.{dataset}.prioritized_kb_entries` as kb_entries
+            JOIN `moz-fx-dev-dschubert-wckb.webcompat_knowledge_base.bugzilla_bugs` as bugzilla_bugs ON bugzilla_bugs.number = kb_entries.core_bug
         WHERE "webcompat:platform-bug" not in UNNEST(bugzilla_bugs.keywords)
         LIMIT {self.normal_changes_max}
         """

--- a/bugbot/rules/webcompat_platform_without_keyword.py
+++ b/bugbot/rules/webcompat_platform_without_keyword.py
@@ -46,7 +46,7 @@ class WebcompatPlatformWithoutKeyword(BzCleaner):
         client = bigquery.Client(project=project, credentials=credentials)
 
         query = f"""
-        SELECT core_bug 
+        SELECT core_bug
         FROM `{project}.{dataset}.prioritized_kb_entries` as kb_entries
             JOIN `moz-fx-dev-dschubert-wckb.webcompat_knowledge_base.bugzilla_bugs` as bugzilla_bugs ON bugzilla_bugs.number = kb_entries.core_bug
         WHERE "webcompat:platform-bug" not in UNNEST(bugzilla_bugs.keywords)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 alembic==1.13.3
 argparse==1.4.0
 filelock==3.16.1
+google-cloud-bigquery==3.24.0
 gspread==6.1.2
 humanize>=0.5.1
 icalendar==5.0.13


### PR DESCRIPTION
This is considered the canonical source for the list of webcompat core bugs, so using it as the backend for the bug-bot rules avoids needing to duplicate the logic across multiple systems.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
