### PR TITLE
Don't close intermittents if they have the 'test-disabled' keyword

### DIFF
--- a/bugbot/rules/close_intermittents.py
+++ b/bugbot/rules/close_intermittents.py
@@ -60,7 +60,7 @@ class Intermittents(BzCleaner):
             "v9": "intermittent-failure",
             "f10": "keywords",
             "o10": "nowords",
-            "v10": "test-verify-fail",
+            "v10": "test-verify-fail,test-disabled",
             "resolution": "---",
             "status_whiteboard_type": "notregexp",
             "status_whiteboard": "(test disabled|test-disabled|testdisabled)",


### PR DESCRIPTION
## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
