### PR TITLE
[user_activity] Removed `user_creation_time` parameter in `get_string_status()`

### DIFF
--- a/bugbot/rules/inactive_ni_pending.py
+++ b/bugbot/rules/inactive_ni_pending.py
@@ -102,7 +102,6 @@ class InactiveNeedinfoPending(BzCleaner):
                     "requestee": flag["requestee"],
                     "requestee_status": user_activity.get_string_status(
                         inactive_users[flag["requestee"]]["status"],
-                        inactive_users[flag["requestee"]]["creation_time"],
                     ),
                     "requestee_canconfirm": has_canconfirm_group(flag["requestee"]),
                 }

--- a/bugbot/user_activity.py
+++ b/bugbot/user_activity.py
@@ -27,6 +27,8 @@ class UserStatus(Enum):
     INACTIVE = auto()
     ABSENT = auto()
     UNAVAILABLE = auto()
+    INACTIVE_NEW = auto()
+    ABSENT_NEW = auto()
 
 
 class UserActivity:
@@ -188,13 +190,13 @@ class UserActivity:
             return UserStatus.ACTIVE
 
         if user["last_seen_date"] is None or user["last_seen_date"] < seen_limit:
-            return UserStatus.ABSENT
+            return UserStatus.ABSENT_NEW if is_new_user else UserStatus.ABSENT
 
         if (
             user["last_activity_time"] is None
             or user["last_activity_time"] < activity_limit
         ):
-            return UserStatus.INACTIVE
+            return UserStatus.INACTIVE_NEW if is_new_user else UserStatus.INACTIVE
 
         return UserStatus.ACTIVE
 
@@ -330,23 +332,20 @@ class UserActivity:
 
         return False
 
-    def get_string_status(self, status: UserStatus, user_creation_time: str):
+    def get_string_status(self, status: UserStatus):
         """Get a string representation of the user status."""
-
-        is_new_user = user_creation_time > self.new_user_limit
-
         if status == UserStatus.UNDEFINED:
             return "Not specified"
         if status == UserStatus.DISABLED:
             return "Account disabled"
         if status == UserStatus.INACTIVE:
-            if is_new_user:
-                return f"Inactive on Bugzilla in last {self.new_user_weeks_count} weeks (new user)"
             return f"Inactive on Bugzilla in last {self.activity_weeks_count} weeks"
         if status == UserStatus.ABSENT:
-            if is_new_user:
-                return f"Not seen on Bugzilla in last {self.new_user_weeks_count} weeks (new user)"
             return f"Not seen on Bugzilla in last {self.absent_weeks_count} weeks"
+        if status == UserStatus.INACTIVE_NEW:
+            return f"Inactive on Bugzilla in last {self.new_user_weeks_count} weeks (new user)"
+        if status == UserStatus.ABSENT_NEW:
+            return f"Not seen on Bugzilla in last {self.new_user_weeks_count} weeks (new user)"
 
         return status.name
 


### PR DESCRIPTION
Resolves #2515.

Introduces two new statuses `INACTIVE_NEW` and `ABSENT_NEW` to remove the second parameter in `get_string_status()`.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
