### PR TITLE
[uplift_beta] Include bugs with needinfos not requested to the bug assignee

### DIFF
--- a/bugbot/rules/uplift_beta.py
+++ b/bugbot/rules/uplift_beta.py
@@ -55,8 +55,6 @@ class UpliftBeta(BzCleaner):
             "nickname": nickname,
             "summary": self.get_summary(bug),
             "regressions": bug["regressions"],
-            "assigned_to": assignee,
-            "flags": bug.get("flags", []),
         }
 
         return bug
@@ -89,14 +87,12 @@ class UpliftBeta(BzCleaner):
         return bugs_without_regr
 
     def is_needinfo_on_assignee(self, flags, assignee):
-        for flag in flags:
-            if (
-                flag["name"] == "needinfo"
-                and flag["status"] == "?"
-                and flag["requestee"] == assignee
-            ):
-                return True
-        return False
+        return any(
+            flag["name"] == "needinfo"
+            and flag["status"] == "?"
+            and flag["requestee"] == assignee
+            for flag in flags
+        )
 
     def get_bz_params(self, date):
         self.date = lmdutils.get_date_ymd(date)

--- a/bugbot/rules/uplift_beta.py
+++ b/bugbot/rules/uplift_beta.py
@@ -134,19 +134,19 @@ class UpliftBeta(BzCleaner):
             "o3": "notsubstring",
             "v3": "approval-mozilla-beta",
             # Don't nag several times
-            "n4": 1,
-            "f4": "longdesc",
-            "o4": "casesubstring",
+            "n5": 1,
+            "f5": "longdesc",
+            "o5": "casesubstring",
             # this a part of the comment we've in templates/uplift_beta_needinfo.txt
-            "v4": ", is this bug important enough to require an uplift?",
+            "v5": ", is this bug important enough to require an uplift?",
             # Check if have at least one attachment which is a Phabricator request
-            "f5": "attachments.mimetype",
-            "o5": "anyexact",
-            "v5": ["text/x-phabricator-request", "text/x-github-pull-request"],
+            "f6": "attachments.mimetype",
+            "o6": "anyexact",
+            "v6": ["text/x-phabricator-request", "text/x-github-pull-request"],
             # skip if whiteboard contains checkin-needed-beta (e.g. test-only uplift)
-            "f6": "status_whiteboard",
-            "o6": "notsubstring",
-            "v6": "[checkin-needed-beta]",
+            "f7": "status_whiteboard",
+            "o7": "notsubstring",
+            "v7": "[checkin-needed-beta]",
         }
 
         return params


### PR DESCRIPTION
Resolves #1666.

Removes the initial Bugzilla search parameter to exclude any bug with a needinfo flag and instead introduces a filter to exclude any bug with a needinfo flag requested to the bug assignee, while including the rest.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
