### PR TITLE
Add additional emails to send to for perfalert_inactive_regression.

### DIFF
--- a/configs/rules.json
+++ b/configs/rules.json
@@ -468,5 +468,8 @@
   "leave_open_sec": {
     "additional_receivers": "rm",
     "days_lookup": 2
+  },
+  "perfalert_inactive_regression": {
+    "additional_receivers": ["perfalert-activity@mozilla.com", "sparky@mozilla.com"]
   }
 }

--- a/templates/perfalert_inactive_regression_needinfo.txt
+++ b/templates/perfalert_inactive_regression_needinfo.txt
@@ -1,4 +1,5 @@
 It has been over {{ extra["nweeks"] * 7 }} days with no activity on this performance regression.
+
 :{{ nickname }}, since you are the author of the regressor, bug {{ extra[bugid]["regressor_id"] }}, which triggered this performance alert, could you please provide a progress update?
 
 If you need additional information/help, please needinfo the performance sheriff who filed this alert (they can be found in comment #0), or reach out in [#perftest](https://matrix.to/#/#perftest:mozilla.org), or [#perfsheriffs](https://matrix.to/#/#perfsheriffs:mozilla.org) on Element.


### PR DESCRIPTION
This patch adds additional emails to send to for changes made by the `perfalert_inactive_regression` rule. It also adds an additional blank line to the needinfo comment.
