### PR TITLE
Add new rule for monitoring performance alert resolution changes.

### DIFF
--- a/bugbot/rules/perfalert_resolved_regression.py
+++ b/bugbot/rules/perfalert_resolved_regression.py
@@ -14,7 +14,6 @@ from bugbot.constants import BOT_MAIN_ACCOUNT
 class PerfAlertResolvedRegression(BzCleaner):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.extra_email_info = {}
         self.extra_ni = {}
 
     def description(self):

--- a/bugbot/rules/perfalert_resolved_regression.py
+++ b/bugbot/rules/perfalert_resolved_regression.py
@@ -10,8 +10,6 @@ from libmozdata.bugzilla import BugzillaUser
 from bugbot.bzcleaner import BzCleaner
 from bugbot.constants import BOT_MAIN_ACCOUNT
 
-DEFAULT_RESOLUTION_COMMENT = "No resolution comment provided."
-
 
 class PerfAlertResolvedRegression(BzCleaner):
     def __init__(self, *args, **kwargs):
@@ -75,14 +73,12 @@ class PerfAlertResolvedRegression(BzCleaner):
         # Check if the bugbot has already needinfo'ed on the bug since
         # the last status change before making one
         for comment in bug_comments[::-1]:
-            if lmdutils.get_date_ymd(comment["creation_time"]) <= status_time:
+            if comment["creation_time"] <= status_time:
                 break
 
             if comment["author"] == BOT_MAIN_ACCOUNT:
                 if (
-                    "comment containing a reason for why the performance regression"
-                    in comment["text"]
-                    or "could you provide a comment explaining the resolution?"
+                    "could you provide a comment explaining the resolution?"
                     in comment["text"]
                 ):
                     # Bugbot has already commented on this bug since the last
@@ -172,7 +168,7 @@ class PerfAlertResolvedRegression(BzCleaner):
 
         # Sometimes a resolution comment is not provided so use a default
         bug_history["needinfo"] = False
-        bug_history["resolution_comment"] = DEFAULT_RESOLUTION_COMMENT
+        bug_history["resolution_comment"] = "N/A"
         for comment in bug_comments[::-1]:
             if (
                 comment["creation_time"] == bug_history["status_time"]
@@ -182,7 +178,7 @@ class PerfAlertResolvedRegression(BzCleaner):
                 break
         else:
             bug_history["needinfo"] = self.should_needinfo(
-                bug_comments, lmdutils.get_date_ymd(bug_history["status_time"])
+                bug_comments, bug_history["status_time"]
             )
 
         data[bug_id] = bug_history

--- a/bugbot/rules/perfalert_resolved_regression.py
+++ b/bugbot/rules/perfalert_resolved_regression.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from datetime import timedelta
+
 from libmozdata import utils as lmdutils
 from libmozdata.bugzilla import BugzillaUser
 
@@ -27,6 +29,9 @@ class PerfAlertResolvedRegression(BzCleaner):
         return self.extra_ni
 
     def get_bz_params(self, date):
+        end_date = lmdutils.get_date_ymd("today")
+        start_date = end_date - timedelta(1)
+
         fields = [
             "id",
             "history",
@@ -50,7 +55,10 @@ class PerfAlertResolvedRegression(BzCleaner):
             "v2": ["regression", "perf-alert"],
             "f4": "resolution",
             "o4": "changedafter",
-            "v4": date,
+            "v4": start_date,
+            "f5": "resolution",
+            "o5": "changedbefore",
+            "v5": end_date,
         }
 
         return params

--- a/bugbot/rules/perfalert_resolved_regression.py
+++ b/bugbot/rules/perfalert_resolved_regression.py
@@ -1,0 +1,107 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from libmozdata.bugzilla import Bugzilla
+
+from bugbot.bzcleaner import BzCleaner
+
+
+class PerfAlertInactiveRegression(BzCleaner):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.extra_email_info = {}
+        self._bug_history = {}
+        self._bug_comments = {}
+
+    def description(self):
+        return "PerfAlert regressions whose resolution has changed recently"
+
+    def get_bz_params(self, date):
+        fields = [
+            "id",
+            "resolution",
+        ]
+
+        # Find all bugs that have perf-alert, and regression in their keywords. Search
+        # for bugs that have been changed in the last day. Only look for bugs after
+        # October 1st, 2024 to prevent triggering comments on older performance regressions
+        params = {
+            "include_fields": fields,
+            "f3": "creation_ts",
+            "o3": "greaterthan",
+            "v3": "2024-10-01T00:00:00Z",
+            "f1": "regressed_by",
+            "o1": "isnotempty",
+            "f2": "keywords",
+            "o2": "allwords",
+            "v2": ["regression", "perf-alert"],
+            "f4": "resolution",
+            "o4": "changedafter",
+            "v4": date,
+        }
+
+        return params
+
+    def get_extra_for_template(self):
+        return self.extra_email_info
+
+    def get_resolution_comments(self, bugs):
+        # Match all the resolutions with resolution comments if they exist
+        for bug_id, bug in bugs.items():
+            bug_comments = self._bug_comments.get(bug_id, [])
+            bug_history = self._bug_history.get(bug_id, {})
+
+            # Sometimes a resolution comment is not provided so use a default
+            bug_history["resolution_comment"] = "No resolution comment provided."
+            for comment in bug_comments[::-1]:
+                if (
+                    comment["creation_time"] == bug_history["resolution_time"]
+                    and comment["author"] == bug_history["resolution_author"]
+                ):
+                    bug_history["resolution_comment"] = comment["text"]
+                    break
+
+            self.extra_email_info[bug_id] = bug_history
+
+    def comment_handler(self, bug, bug_id, bugs):
+        # Gather all comments to match them with the history after
+        self._bug_comments[bug_id] = bug["comments"]
+
+    def history_handler(self, bug):
+        bug_info = self._bug_history.setdefault(str(bug["id"]), {})
+
+        # Get the last resolution change that was made in this bug
+        for change in bug["history"][::-1]:
+            for specific_change in change["changes"]:
+                if specific_change["field_name"] == "status" and specific_change[
+                    "added"
+                ] in ("RESOLVED", "REOPENED"):
+                    bug_info["resolution_time"] = change["when"]
+                    bug_info["resolution_author"] = change["who"]
+                    bug_info["resolution"] = specific_change["added"]
+                    break
+            if bug_info.get("resolution_author"):
+                break
+
+    def gather_bugs_info(self, bugs):
+        Bugzilla(
+            bugids=self.get_list_bugs(bugs),
+            historyhandler=self.history_handler,
+            commenthandler=self.comment_handler,
+            commentdata=bugs,
+            comment_include_fields=["text", "creation_time", "author"],
+        ).get_data().wait()
+
+        # Match the history with comments to get resolution reasons
+        self.get_resolution_comments(bugs)
+
+    def get_bugs(self, *args, **kwargs):
+        bugs = super().get_bugs(*args, **kwargs)
+        self.gather_bugs_info(bugs)
+        return bugs
+
+
+if __name__ == "__main__":
+    PerfAlertInactiveRegression().run()

--- a/bugbot/rules/perfalert_resolved_regression.py
+++ b/bugbot/rules/perfalert_resolved_regression.py
@@ -2,16 +2,20 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
-from libmozdata.bugzilla import Bugzilla
+from libmozdata import utils as lmdutils
+from libmozdata.bugzilla import Bugzilla, BugzillaUser
 
 from bugbot.bzcleaner import BzCleaner
+from bugbot.constants import BOT_MAIN_ACCOUNT
+
+DEFAULT_RESOLUTION_COMMENT = "No resolution comment provided."
 
 
-class PerfAlertInactiveRegression(BzCleaner):
+class PerfAlertResolvedRegression(BzCleaner):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.extra_email_info = {}
+        self.extra_ni = {}
         self._bug_history = {}
         self._bug_comments = {}
 
@@ -47,6 +51,9 @@ class PerfAlertInactiveRegression(BzCleaner):
     def get_extra_for_template(self):
         return self.extra_email_info
 
+    def get_extra_for_needinfo_template(self):
+        return self.extra_ni
+
     def get_resolution_comments(self, bugs):
         # Match all the resolutions with resolution comments if they exist
         for bug_id, bug in bugs.items():
@@ -54,16 +61,59 @@ class PerfAlertInactiveRegression(BzCleaner):
             bug_history = self._bug_history.get(bug_id, {})
 
             # Sometimes a resolution comment is not provided so use a default
-            bug_history["resolution_comment"] = "No resolution comment provided."
+            bug_history["resolution_comment"] = DEFAULT_RESOLUTION_COMMENT
             for comment in bug_comments[::-1]:
                 if (
-                    comment["creation_time"] == bug_history["resolution_time"]
-                    and comment["author"] == bug_history["resolution_author"]
+                    comment["creation_time"] == bug_history["status_time"]
+                    and comment["author"] == bug_history["status_author"]
                 ):
                     bug_history["resolution_comment"] = comment["text"]
                     break
+            else:
+                # Check if the bugbot has already needinfo'ed on the bug since
+                # the last status change before making one
+                skip_ni = False
+                status_time = lmdutils.get_date_ymd(bug_history["status_time"])
+                for comment in bug_comments[::-1]:
+                    if lmdutils.get_date_ymd(comment["creation_time"]) <= status_time:
+                        break
+
+                    if comment["author"] == BOT_MAIN_ACCOUNT:
+                        if (
+                            "comment containing a reason for why"
+                            "the performance regression"
+                            in comment["text"]
+                            or "could you provide a comment explaining the resolution?"
+                            in comment["text"]
+                        ):
+                            # Bugbot has already commented on this bug since the last
+                            # status change. No need to comment again since this was
+                            # just a resolution change
+                            skip_ni = True
+
+                if not skip_ni:
+                    self.extra_ni[bug_id] = bug_history
 
             self.extra_email_info[bug_id] = bug_history
+
+    def get_needinfo_nicks(self):
+        if not self.extra_ni:
+            return
+
+        def _user_handler(user, data):
+            data[user["name"]] = user.get("nick", "")
+
+        user_emails_to_names = {}
+        BugzillaUser(
+            user_names=[bug_ni["status_author"] for bug_ni in self.extra_ni.values()],
+            include_fields=["nick", "name"],
+            user_handler=_user_handler,
+            user_data=user_emails_to_names,
+        ).wait()
+
+        for bug_id, bug_info in self.extra_ni.items():
+            if bug_info["status_author"] in user_emails_to_names:
+                bug_info["nickname"] = user_emails_to_names[bug_info["status_author"]]
 
     def comment_handler(self, bug, bug_id, bugs):
         # Gather all comments to match them with the history after
@@ -74,15 +124,30 @@ class PerfAlertInactiveRegression(BzCleaner):
 
         # Get the last resolution change that was made in this bug
         for change in bug["history"][::-1]:
-            for specific_change in change["changes"]:
-                if specific_change["field_name"] == "status" and specific_change[
-                    "added"
-                ] in ("RESOLVED", "REOPENED"):
-                    bug_info["resolution_time"] = change["when"]
-                    bug_info["resolution_author"] = change["who"]
-                    bug_info["resolution"] = specific_change["added"]
-                    break
-            if bug_info.get("resolution_author"):
+            # Get the most recent resolution change first, this is because
+            # it could have changed since the status was changed and by who
+            if not bug_info.get("resolution"):
+                for specific_change in change["changes"]:
+                    if specific_change["field_name"] == "resolution":
+                        bug_info["resolution"] = specific_change["added"]
+                        bug_info["resolution_previous"] = (
+                            specific_change["removed"].strip() or "---"
+                        )
+                        bug_info["resolution_time"] = change["when"]
+                        break
+
+            if bug_info.get("resolution"):
+                # Find the status that the bug was resolved to, and by who
+                for specific_change in change["changes"]:
+                    if specific_change["field_name"] == "status" and specific_change[
+                        "added"
+                    ] in ("RESOLVED", "REOPENED"):
+                        bug_info["status"] = specific_change["added"]
+                        bug_info["status_author"] = change["who"]
+                        bug_info["status_time"] = change["when"]
+                        break
+
+            if bug_info.get("status"):
                 break
 
     def gather_bugs_info(self, bugs):
@@ -97,11 +162,29 @@ class PerfAlertInactiveRegression(BzCleaner):
         # Match the history with comments to get resolution reasons
         self.get_resolution_comments(bugs)
 
+        # Get info for needinfos
+        self.get_needinfo_nicks()
+
+    def set_autofix(self, bugs):
+        for bug_id, bug_info in self.extra_ni.items():
+            self.add_auto_ni(
+                bug_id,
+                {
+                    "mail": bug_info["status_author"],
+                    "nickname": (
+                        (":" + bug_info["nickname"])
+                        if "nickname" in bug_info
+                        else bug_info["status_author"]
+                    ),
+                },
+            )
+
     def get_bugs(self, *args, **kwargs):
         bugs = super().get_bugs(*args, **kwargs)
         self.gather_bugs_info(bugs)
+        self.set_autofix(bugs)
         return bugs
 
 
 if __name__ == "__main__":
-    PerfAlertInactiveRegression().run()
+    PerfAlertResolvedRegression().run()

--- a/bugbot/rules/perfalert_resolved_regression.py
+++ b/bugbot/rules/perfalert_resolved_regression.py
@@ -142,7 +142,7 @@ class PerfAlertResolvedRegression(BzCleaner):
 
     def get_needinfo_nicks(self, bugs):
         def _user_handler(user, data):
-            data[user["name"]] = user.get("nick", "")
+            data[user["name"]] = user["nick"]
 
         authors_to_ni = set()
         for bug_id, bug_info in bugs.items():

--- a/configs/rules.json
+++ b/configs/rules.json
@@ -471,5 +471,8 @@
   },
   "perfalert_inactive_regression": {
     "additional_receivers": ["perfalert-activity@mozilla.com", "sparky@mozilla.com"]
+  },
+  "perfalert_resolved_regression": {
+    "additional_receivers": ["perfalert-activity@mozilla.com", "sparky@mozilla.com"]
   }
 }

--- a/scripts/cron_run_daily.sh
+++ b/scripts/cron_run_daily.sh
@@ -18,6 +18,9 @@ python -m bugbot.rules.performancebug --production
 # Try to detect potential performance alerts that have been inactive for too long
 python -m bugbot.rules.perfalert_inactive_regression --production
 
+# Send an email about all performance alerts who were recently resolved
+python -m bugbot.rules.perfalert_resolved_regression --production
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m bugbot.log --send

--- a/templates/perfalert_resolved_regression.html
+++ b/templates/perfalert_resolved_regression.html
@@ -4,6 +4,7 @@
         <tr>
             <th>Bug</th>
             <th>Summary</th>
+            <th>Status</th>
             <th>Resolution</th>
         </tr>
     </thead>
@@ -27,12 +28,13 @@
                     </tr>
                     <tr>
                         <td>
-                            <i>Resolved by {{ extra[bugid]["resolution_author"] }}</i>
+                            <i>Resolved by {{ extra[bugid]["status_author"] }}</i>
                         </td>
                     </tr>
                 </table>
             </td>
-            <td>{{ extra[bugid]["resolution"] }}</td>
+            <td>{{ extra[bugid]["status"] }}</td>
+            <td>{{ extra[bugid]["resolution_previous"] }} -> {{ extra[bugid]["resolution"] }}</td>
         </tr>
     {% endfor -%}
 </tbody>

--- a/templates/perfalert_resolved_regression.html
+++ b/templates/perfalert_resolved_regression.html
@@ -1,0 +1,39 @@
+<p>The following bug list contains performance alerts whose resolution has changed in the last week:</p>
+<table {{ table_attrs }}>
+    <thead>
+        <tr>
+            <th>Bug</th>
+            <th>Summary</th>
+            <th>Resolution</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for i, (bugid, summary) in enumerate(data) -%}
+            <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
+            {% endif -%}
+            >
+            <td>
+                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+            </td>
+            <td>
+                <table>
+                    <tr>
+                        <td>{{ summary | e }}</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <b>Resolution Comment:</b> {{ extra[bugid]["resolution_comment"] }}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <i>Resolved by {{ extra[bugid]["resolution_author"] }}</i>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+            <td>{{ extra[bugid]["resolution"] }}</td>
+        </tr>
+    {% endfor -%}
+</tbody>
+</table>

--- a/templates/perfalert_resolved_regression.html
+++ b/templates/perfalert_resolved_regression.html
@@ -9,7 +9,7 @@
         </tr>
     </thead>
     <tbody>
-        {% for i, (bugid, summary) in enumerate(data) -%}
+        {% for i, (bugid, summary, status, status_author, resolution, resolution_comment, resolution_previous) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
@@ -23,18 +23,18 @@
                     </tr>
                     <tr>
                         <td>
-                            <b>Resolution Comment:</b> {{ extra[bugid]["resolution_comment"] }}
+                            <b>Resolution Comment:</b> {{ resolution_comment }}
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <i>Resolved by {{ extra[bugid]["status_author"] }}</i>
+                            <i>Resolved by {{ status_author }}</i>
                         </td>
                     </tr>
                 </table>
             </td>
-            <td>{{ extra[bugid]["status"] }}</td>
-            <td>{{ extra[bugid]["resolution_previous"] }} -> {{ extra[bugid]["resolution"] }}</td>
+            <td>{{ status }}</td>
+            <td>{{ resolution_previous }} -> {{ resolution }}</td>
         </tr>
     {% endfor -%}
 </tbody>

--- a/templates/perfalert_resolved_regression_needinfo.txt
+++ b/templates/perfalert_resolved_regression_needinfo.txt
@@ -1,6 +1,6 @@
 A comment containing a reason for why the performance regression was {{ "resolved as " + extra[bugid]["resolution"] if extra[bugid]["status"].lower() == "resolved" else "reopened" }} could not be found. It should provided when the status of the bug is changed.
 
-{{ nickname }}, since you resolved this bug, could you provide a comment explaining the resolution? If one has already been provided, this needinfo can be ignored/removed.
+:{{ nickname }}, since you resolved this bug, could you provide a comment explaining the resolution? If one has already been provided, this needinfo can be ignored/removed.
 
 If you need additional information/help, reach out in [#perftest](https://matrix.to/#/#perftest:mozilla.org), or [#perfsheriffs](https://matrix.to/#/#perfsheriffs:mozilla.org) on Element.
 

--- a/templates/perfalert_resolved_regression_needinfo.txt
+++ b/templates/perfalert_resolved_regression_needinfo.txt
@@ -1,0 +1,7 @@
+A comment containing a reason for why the performance regression was {{ "resolved as " + extra[bugid]["resolution"] if extra[bugid]["status"].lower() == "resolved" else "reopened" }} could not be found. It should provided when the status of the bug is changed.
+
+{{ nickname }}, since you resolved this bug, could you provide a comment explaining the resolution? If one has already been provided, this needinfo can be ignored/removed.
+
+If you need additional information/help, reach out in [#perftest](https://matrix.to/#/#perftest:mozilla.org), or [#perfsheriffs](https://matrix.to/#/#perfsheriffs:mozilla.org) on Element.
+
+{{ documentation }}


### PR DESCRIPTION
This PR adds a new rule to monitor perfalert resolution changes. It will send out an email which provides a summary of all the performance alerts which have had their resolution changed within the last day. It includes the resolution comment, and author in the email as well.