### PR TITLE
Fix wording in the resolved alerts rule email.

### DIFF
--- a/templates/perfalert_resolved_regression.html
+++ b/templates/perfalert_resolved_regression.html
@@ -1,4 +1,4 @@
-<p>The following bug list contains performance alerts whose resolution has changed in the last week:</p>
+<p>The following bug list contains performance alerts whose resolution has changed during the previous day:</p>
 <table {{ table_attrs }}>
     <thead>
         <tr>


### PR DESCRIPTION
This patch fixes an issue in the resolved performance alerts rule to mention in the previous day instead of in the last week.