### PR TITLE
Mention resolving perfalert as WONTFIX, and don't needinfo on bugs with backlog-deferred keyword.

### DIFF
--- a/bugbot/rules/perfalert_inactive_regression.py
+++ b/bugbot/rules/perfalert_inactive_regression.py
@@ -46,17 +46,20 @@ class PerfAlertInactiveRegression(BzCleaner):
         # performance regressions
         params = {
             "include_fields": fields,
-            "f3": "creation_ts",
-            "o3": "greaterthan",
-            "v3": "2024-10-01T00:00:00Z",
-            "f1": "regressed_by",
-            "o1": "isnotempty",
-            "f2": "keywords",
-            "o2": "allwords",
-            "v2": ["regression", "perf-alert"],
-            "f9": "days_elapsed",
-            "o9": "greaterthan",
-            "v9": self.nweeks * 7,
+            "f1": "creation_ts",
+            "o1": "greaterthan",
+            "v1": "2024-10-01T00:00:00Z",
+            "f2": "regressed_by",
+            "o2": "isnotempty",
+            "f3": "keywords",
+            "o3": "allwords",
+            "v3": ["regression", "perf-alert"],
+            "f4": "keywords",
+            "o4": "nowords",
+            "v4": "backlog-deferred",
+            "f5": "days_elapsed",
+            "o5": "greaterthan",
+            "v5": self.nweeks * 7,
             "status": ["UNCONFIRMED", "NEW", "REOPENED"],
             "resolution": ["---"],
         }
@@ -89,7 +92,7 @@ class PerfAlertInactiveRegression(BzCleaner):
         # TODO: Attempt to needinfo the triage owner instead of ignoring the bugs
         # Exclude bugs whose regressor author is nobody.
         for bug in list(bugs.values()):
-            if utils.is_no_assignee(bug["regressor_author_email"]):
+            if utils.is_no_assignee(bug.get("regressor_author_email", "")):
                 logger.warning(
                     "Bug {}, regressor of bug {}, doesn't have an author".format(
                         bug["regressor_id"], bug["id"]

--- a/templates/perfalert_inactive_regression_needinfo.txt
+++ b/templates/perfalert_inactive_regression_needinfo.txt
@@ -2,6 +2,8 @@ It has been over {{ extra["nweeks"] * 7 }} days with no activity on this perform
 
 :{{ nickname }}, since you are the author of the regressor, bug {{ extra[bugid]["regressor_id"] }}, which triggered this performance alert, could you please provide a progress update?
 
-If you need additional information/help, please needinfo the performance sheriff who filed this alert (they can be found in comment #0), or reach out in [#perftest](https://matrix.to/#/#perftest:mozilla.org), or [#perfsheriffs](https://matrix.to/#/#perfsheriffs:mozilla.org) on Element.
+If this regression is something that fixes a bug, changes the baseline of the regression metrics, or otherwise will not be fixed, please consider closing it as WONTFIX. [See this documentation for more information on how to handle regressions](https://firefox-source-docs.mozilla.org/testing/perfdocs/perftest-in-a-nutshell.html#help-i-have-a-regression-what-do-i-do).
+
+For additional information/help, please needinfo the performance sheriff who filed this alert (they can be found in comment #0), or reach out in [#perftest](https://matrix.to/#/#perftest:mozilla.org), or [#perfsheriffs](https://matrix.to/#/#perfsheriffs:mozilla.org) on Element.
 
 {{ documentation }}


### PR DESCRIPTION
This patch adds some additional text to the needinfo to ask the developer to close the bug as WONTFIX if it's appropriate, and provides some documentation to help them with this decision.

At the same time, a `backlog-deferred` keyword check is added to prevent bugbot from making needinfo's on bugs who have this set. It signifies that the regression is valid, needs to be fixed or better understood, but won't be immediately fixed. It's not mentioned in the needinfo comment since it should be used sparingly, and in cases where this keyword is set, a follow-up bug can usually be made to look into the issue while resolving the alert as a WONTFIX.

Furthermore, locally, private regressors cause failures so the retrieval of the regressor email is changed to use a get instead.