### PR TITLE
chore: use include_fields in round_robin and no_assignee

### DIFF
--- a/bugbot/round_robin.py
+++ b/bugbot/round_robin.py
@@ -132,7 +132,9 @@ class RoundRobin(object):
             def handler(user):
                 self.nicks[bzmail] = user["nick"]
 
-            BugzillaUser(user_names=[bzmail], user_handler=handler).wait()
+            BugzillaUser(
+                user_names=[bzmail], user_handler=handler, include_fields=["nick"]
+            ).wait()
 
         if bzmail not in self.nicks:
             self.add_erroneous_bzmail(bzmail, prod_comp, cal)

--- a/bugbot/rules/no_assignee.py
+++ b/bugbot/rules/no_assignee.py
@@ -134,7 +134,10 @@ class NoAssignee(BzCleaner):
 
         if users:
             BugzillaUser(
-                user_names=list(users), user_handler=handler, user_data=data
+                user_names=list(users),
+                user_handler=handler,
+                user_data=data,
+                include_fields=["name", "real_name"],
             ).wait()
 
         return data


### PR DESCRIPTION
This PR adds include_fields to only retrieve fields we actually need in the following files :
- bugbot/rules/no_assignee.py
- bugbot/round_robin.py

Fixes #1102 

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [x] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
