### PR TITLE
[component] Added explicit skip for Fenix::General bugs not being reclassified

### DIFF
--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -130,6 +130,12 @@ class Component(BzCleaner):
                 if confidence > self.fenix_confidence_threshold:
                     data["class"] = f"Fenix::{data['class']}"
                     bugs[bug_id] = data
+                else:
+                    if (
+                        raw_bugs[bug_id]["product"] == "Fenix"
+                        and raw_bugs[bug_id]["component"] == "General"
+                    ):
+                        continue
 
         results = {}
 

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -129,7 +129,11 @@ class Component(BzCleaner):
                 confidence = data["prob"][data["index"]]
 
                 if confidence > self.fenix_confidence_threshold:
-                    data["class"] = f"Fenix::{data['class']}"
+                    print(f"classification: {data['class']}")
+                    if data["class"] == "General":
+                        data["class"] = "GeckoView::General"
+                    else:
+                        data["class"] = f"Fenix::{data['class']}"
                     bugs[bug_id] = data
 
         results = {}
@@ -158,10 +162,8 @@ class Component(BzCleaner):
             if "::" not in suggestion and bug["product"] == suggestion:
                 continue
 
-            # No need to move a Fenix::General bug to Fenix::General
-            if (
-                bug["product"] == "Fenix" and bug["component"] == "General"
-            ) and suggestion == "Fenix::General":
+            # No need to move a bug to the same component.
+            if f"{bug["product"]}::{bug["component"]}" == suggestion:
                 continue
 
             suggestion = conflated_components_mapping.get(suggestion, suggestion)

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 from libmozdata.bugzilla import Bugzilla
 
 from bugbot import logger

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
 from libmozdata.bugzilla import Bugzilla
 
 from bugbot import logger
@@ -130,12 +131,6 @@ class Component(BzCleaner):
                 if confidence > self.fenix_confidence_threshold:
                     data["class"] = f"Fenix::{data['class']}"
                     bugs[bug_id] = data
-                else:
-                    if (
-                        raw_bugs[bug_id]["product"] == "Fenix"
-                        and raw_bugs[bug_id]["component"] == "General"
-                    ):
-                        continue
 
         results = {}
 
@@ -161,6 +156,12 @@ class Component(BzCleaner):
 
             # Skip product-only suggestions that are not useful.
             if "::" not in suggestion and bug["product"] == suggestion:
+                continue
+
+            # No need to move a Fenix::General bug to Fenix::General
+            if (
+                bug["product"] == "Fenix" and bug["component"] == "General"
+            ) and suggestion == "Fenix::General":
                 continue
 
             suggestion = conflated_components_mapping.get(suggestion, suggestion)

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -128,12 +128,11 @@ class Component(BzCleaner):
             for bug_id, data in fenix_general_classification.items():
                 confidence = data["prob"][data["index"]]
 
-                if confidence > self.fenix_confidence_threshold:
-                    print(f"classification: {data['class']}")
-                    if data["class"] == "General":
-                        data["class"] = "GeckoView::General"
-                    else:
-                        data["class"] = f"Fenix::{data['class']}"
+                if (
+                    confidence > self.fenix_confidence_threshold
+                    and data["class"] != "General"
+                ):
+                    data["class"] = f"Fenix::{data['class']}"
                     bugs[bug_id] = data
 
         results = {}

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -163,7 +163,7 @@ class Component(BzCleaner):
                 continue
 
             # No need to move a bug to the same component.
-            if f"{bug["product"]}::{bug["component"]}" == suggestion:
+            if f"{bug['product']}::{bug['component']}" == suggestion:
                 continue
 
             suggestion = conflated_components_mapping.get(suggestion, suggestion)


### PR DESCRIPTION
Resolves #2585.

Added explicit `continue` for originally `Fenix::General` bugs not being reclassified to anything else to avoid being "moved" to `Fenix::General` again. (Also applicable to all bugs that are being moved to the same product component pair)

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
