### PR TITLE
Add logic to check deeper for perfalert resolution comments.

### DIFF
--- a/bugbot/rules/perfalert_resolved_regression.py
+++ b/bugbot/rules/perfalert_resolved_regression.py
@@ -64,7 +64,7 @@ class PerfAlertResolvedRegression(BzCleaner):
 
     def get_bz_params(self, date):
         end_date = lmdutils.get_date_ymd("today")
-        start_date = end_date - timedelta(14)
+        start_date = end_date - timedelta(1)
 
         fields = [
             "id",

--- a/bugbot/rules/perfalert_resolved_regression.py
+++ b/bugbot/rules/perfalert_resolved_regression.py
@@ -29,6 +29,17 @@ RESOLUTION_KEYWORDS = (
 
 class PerfAlertResolvedRegression(BzCleaner):
     def __init__(self, max_seconds_to_status=86400):
+        """
+        Initializes the bugbot rule for ensuring performance alerts
+        have a valid resolution comment when they are closed.
+
+        :param max_seconds_to_status int: When a resolution comment is not provided
+            at the time of resolution, the preceding comment can be considered as a
+            resolution comment as long it hasn't been more than `max_seconds_to_status`
+            seconds since the comment was made. Only applies when the resolution
+            author is different from the preceding comment author, otherwise, the
+            comment is accepted without checking the time that has elapsed.
+        """
         super().__init__()
         self.max_seconds_to_status = max_seconds_to_status
         self.extra_ni = {}

--- a/bugbot/rules/perfalert_resolved_regression.py
+++ b/bugbot/rules/perfalert_resolved_regression.py
@@ -33,7 +33,7 @@ class PerfAlertResolvedRegression(BzCleaner):
         Initializes the bugbot rule for ensuring performance alerts
         have a valid resolution comment when they are closed.
 
-        :param max_seconds_before_status int: When a resolution comment is not provided
+        max_seconds_before_status int: When a resolution comment is not provided
             at the time of resolution, the preceding comment can be considered as a
             resolution comment as long it hasn't been more than `max_seconds_before_status`
             seconds since the comment was made. Only applies when the resolution

--- a/bugbot/rules/perfalert_resolved_regression.py
+++ b/bugbot/rules/perfalert_resolved_regression.py
@@ -28,20 +28,20 @@ RESOLUTION_KEYWORDS = (
 
 
 class PerfAlertResolvedRegression(BzCleaner):
-    def __init__(self, max_seconds_to_status=86400):
+    def __init__(self, max_seconds_before_status=86400):
         """
         Initializes the bugbot rule for ensuring performance alerts
         have a valid resolution comment when they are closed.
 
-        :param max_seconds_to_status int: When a resolution comment is not provided
+        :param max_seconds_before_status int: When a resolution comment is not provided
             at the time of resolution, the preceding comment can be considered as a
-            resolution comment as long it hasn't been more than `max_seconds_to_status`
+            resolution comment as long it hasn't been more than `max_seconds_before_status`
             seconds since the comment was made. Only applies when the resolution
             author is different from the preceding comment author, otherwise, the
             comment is accepted without checking the time that has elapsed.
         """
         super().__init__()
-        self.max_seconds_to_status = max_seconds_to_status
+        self.max_seconds_before_status = max_seconds_before_status
         self.extra_ni = {}
 
     def description(self):
@@ -159,7 +159,7 @@ class PerfAlertResolvedRegression(BzCleaner):
             if (
                 lmdutils.get_timestamp(status_time)
                 - lmdutils.get_timestamp(preceding_comment["creation_time"])
-            ) < self.max_seconds_to_status:
+            ) < self.max_seconds_before_status:
                 # Accept if the previous comment from another author is
                 # within the time limit
                 return preceding_resolution_comment

--- a/templates/perfalert_resolved_regression.html
+++ b/templates/perfalert_resolved_regression.html
@@ -6,10 +6,11 @@
             <th>Summary</th>
             <th>Status</th>
             <th>Resolution</th>
+            <th>Needinfo</th>
         </tr>
     </thead>
     <tbody>
-        {% for i, (bugid, summary, status, status_author, resolution, resolution_comment, resolution_previous) in enumerate(data) -%}
+        {% for i, (bugid, summary, status, status_author, resolution, resolution_comment, resolution_previous, needinfo) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
@@ -35,6 +36,7 @@
             </td>
             <td>{{ status }}</td>
             <td>{{ resolution_previous }} -> {{ resolution }}</td>
+            <td>{{ "Yes" if needinfo else "No"}}</td>
         </tr>
     {% endfor -%}
 </tbody>


### PR DESCRIPTION
This patch changes the perfalert resolution rule to check for some additional cases where a comment may have already been provided. Specifically, it now checks for the following:
1. The status author made a comment at the same time as changing the resolution.
2. The status author made a comment just before changing the resolution.
3. Another user provided a resolution comment just before the resolution was made (checked with keywords).

The code was also modified to make it simpler to add more checks in the future.