### PR TITLE
Add fbraun to additional_receivers for fuzzblockers

### DIFF
--- a/configs/rules.json
+++ b/configs/rules.json
@@ -66,7 +66,7 @@
     "must_run": ["Mon"]
   },
   "fuzz_blockers": {
-    "must_run": ["Mon"]
+    "must_run": ["Mon"],
     "additional_receivers": ["fbraun@mozilla.com"]
   },
   "patch_closed_bug": {

--- a/configs/rules.json
+++ b/configs/rules.json
@@ -67,6 +67,7 @@
   },
   "fuzz_blockers": {
     "must_run": ["Mon"]
+    "additional_receivers": ["fbraun@mozilla.com"]
   },
   "patch_closed_bug": {
     "additional_receivers": "rm"


### PR DESCRIPTION
This adds the `additional_receivers` for the fuzzblockers rule with just one entry (myself)
I would like to do this to get better insights into where our fuzzing is limited by new and existing fuzzblockers.


## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing

**I think none of the above applies.** I am not changing behavior, but just adding an email address.