### PR TITLE
Disabled missed_landing_commits rule until metadata used is correct again

### DIFF
--- a/scripts/cron_run_weekdays.sh
+++ b/scripts/cron_run_weekdays.sh
@@ -115,6 +115,8 @@ python -m bugbot.rules.stepstoreproduce --production
 python -m bugbot.rules.good_first_bug_unassign_inactive --production
 
 # Look for missing bugzilla comments for recently-landed changesets
+# Temporarily disabled until backout commit messages are well-formatted again
+# by lando_cli tool.
 python -m bugbot.rules.missed_landing_comment --production
 
 # Look for recently landed changesets referencing leave-open security bugs

--- a/scripts/cron_run_weekdays.sh
+++ b/scripts/cron_run_weekdays.sh
@@ -117,7 +117,7 @@ python -m bugbot.rules.good_first_bug_unassign_inactive --production
 # Look for missing bugzilla comments for recently-landed changesets
 # NOTE: Temporarily disabled until backout commit messages are well-formatted
 # again by lando_cli tool.
-python -m bugbot.rules.missed_landing_comment --production
+# python -m bugbot.rules.missed_landing_comment --production
 
 # Look for recently landed changesets referencing leave-open security bugs
 python -m bugbot.rules.leave_open_sec --production

--- a/scripts/cron_run_weekdays.sh
+++ b/scripts/cron_run_weekdays.sh
@@ -115,8 +115,8 @@ python -m bugbot.rules.stepstoreproduce --production
 python -m bugbot.rules.good_first_bug_unassign_inactive --production
 
 # Look for missing bugzilla comments for recently-landed changesets
-# Temporarily disabled until backout commit messages are well-formatted again
-# by lando_cli tool.
+# NOTE: Temporarily disabled until backout commit messages are well-formatted
+# again by lando_cli tool.
 python -m bugbot.rules.missed_landing_comment --production
 
 # Look for recently landed changesets referencing leave-open security bugs


### PR DESCRIPTION
Resolves #2633 

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing