### PR TITLE
Improve CPU-based crash filtering logic

### DIFF
--- a/bugbot/crash/analyzer.py
+++ b/bugbot/crash/analyzer.py
@@ -792,11 +792,13 @@ class SignaturesDataFetcher:
                     # The crash is not new, skip it.
                     continue
 
-                if any(
-                    cpu_info["term"] == "family 6 model 183 stepping 1"
+                broken_cpu_count = sum(
+                    cpu_info["count"]
                     for cpu_info in facets["cpu_info"]
-                ):
-                    # Ignore crashes that are likely caused by a broken CPU.
+                    if cpu_info["term"] == "family 6 model 183 stepping 1"
+                )
+                if broken_cpu_count / crash["count"] >= 0.7:
+                    # Ignore signatures that are likely caused by a broken CPU.
                     continue
 
                 if any(


### PR DESCRIPTION
Follow up on https://github.com/mozilla/bugbot/issues/2659

Refines the logic to ignore signatures likely caused by a broken CPU by checking if at least 70% of crashes are from the affected CPU model, rather than any occurrence. This reduces false negatives in crash analysis.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
