### PR TITLE
Remove leave-open keyword when closing intermittent bugs

### DIFF
--- a/bugbot/rules/close_intermittents.py
+++ b/bugbot/rules/close_intermittents.py
@@ -79,6 +79,7 @@ class Intermittents(BzCleaner):
             **status_flags,
             "status": "RESOLVED",
             "resolution": "INCOMPLETE",
+            "keywords": {"remove": ["leave-open"]},
             "comment": {
                 "body": f"https://wiki.mozilla.org/Bug_Triage#Intermittent_Test_Failure_Cleanup\n{self.get_documentation()}"
             },


### PR DESCRIPTION
Fixes #2504

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
