### PR TITLE
Add a rule to add See Also links to bugs tagged with web-features

### DIFF
--- a/bugbot/rules/web_platform_features.py
+++ b/bugbot/rules/web_platform_features.py
@@ -1,0 +1,129 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import urllib
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional
+
+from bugbot import gcp
+from bugbot.bzcleaner import BzCleaner
+
+
+@dataclass
+class FeatureUrls:
+    feature: str
+    spec_url: Optional[list[str]]
+    feature_url: str
+    sp_url: Optional[str]
+
+
+def url_keys(urls: Iterable[str]) -> Mapping[tuple[str, str], str]:
+    rv = {}
+    for url in urls:
+        try:
+            parsed = urllib.parse.urlparse(url)
+            if parsed.hostname is None:
+                continue
+            rv[(parsed.hostname, parsed.path)] = url
+        except ValueError:
+            pass
+    return rv
+
+
+class WebPlatformFeatures(BzCleaner):
+    def __init__(self) -> None:
+        super().__init__()
+        self.feature_bugs: Mapping[int, FeatureUrls] = {}
+
+    def description(self) -> str:
+        return "Update See Also for web-features bugs"
+
+    def filter_no_nag_keyword(self) -> bool:
+        return False
+
+    def has_default_products(self) -> bool:
+        return False
+
+    def columns(self) -> list[str]:
+        return ["id", "summary", "added"]
+
+    def handle_bug(
+        self, bug: dict[str, Any], data: dict[str, Any]
+    ) -> Optional[dict[str, Any]]:
+        features_key = bug["id"]
+        bug_id = str(bug["id"])
+
+        changes = {}
+        if bug_id not in data:
+            data[bug_id] = {}
+        data[bug_id]["added"] = []
+        if features_key in self.feature_bugs:
+            see_also_keys = url_keys(bug["see_also"])
+
+            feature_urls = self.feature_bugs[features_key]
+            expected_urls = [feature_urls.feature_url]
+            if feature_urls.sp_url is not None:
+                expected_urls.append(feature_urls.sp_url)
+            if feature_urls.spec_url is not None:
+                expected_urls.extend(feature_urls.spec_url)
+            expected_keys = url_keys(expected_urls)
+            add_urls = [
+                url for key, url in expected_keys.items() if key not in see_also_keys
+            ]
+            if add_urls:
+                changes["see_also"] = bug["see_also"] + add_urls
+                data[bug_id]["added"] = add_urls
+
+        if changes:
+            self.autofix_changes[bug_id] = changes
+            return bug
+
+        return None
+
+    def get_bz_params(self, date) -> dict[str, str | int | list[str] | list[int]]:
+        fields = ["id", "see_also"]
+        self.feature_bugs = self.get_feature_bugs()
+        print(self.feature_bugs)
+        return {"include_fields": fields, "id": list(self.feature_bugs.keys())}
+
+    def get_feature_bugs(self) -> Mapping[int, FeatureUrls]:
+        project = "moz-fx-dev-dschubert-wckb"
+
+        client = gcp.get_bigquery_client(project, ["cloud-platform", "drive"])
+        query = f"""
+WITH feature_bugs as (
+  SELECT
+    bugs.number,
+    feature,
+    bugs.see_also,
+    web_features.spec as spec_url,
+    concat("https://web-platform-dx.github.io/web-features-explorer/features/", feature, "/") as feature_url,
+    concat("https://github.com/mozilla/standards-positions/issues/", sp_mozilla.issue) as sp_url
+  FROM `{project}.webcompat_knowledge_base.bugzilla_bugs` AS bugs
+  JOIN `{project}.web_features.features_latest` AS web_features
+    ON web_features.feature IN UNNEST(`{project}.webcompat_knowledge_base.EXTRACT_ARRAY`(bugs.user_story, "$.web-feature"))
+  LEFT JOIN `{project}.standards_positions.mozilla_standards_positions` AS sp_mozilla
+    ON `{project}.webcompat_knowledge_base.BUG_ID_FROM_BUGZILLA_URL`(sp_mozilla.bug) = bugs.number
+)
+
+SELECT number, feature, spec_url, feature_url, sp_url FROM feature_bugs
+WHERE
+  NOT EXISTS(SELECT 1 FROM feature_bugs.spec_url WHERE spec_url NOT IN UNNEST(see_also))
+  OR feature_url NOT IN UNNEST(see_also)
+  OR sp_url NOT IN UNNEST(see_also)
+"""
+
+        return {
+            row["number"]: FeatureUrls(
+                feature=row["feature"],
+                spec_url=row["spec_url"],
+                feature_url=row["feature_url"],
+                sp_url=row["sp_url"],
+            )
+            for row in client.query(query).result()
+        }
+
+
+if __name__ == "__main__":
+    WebPlatformFeatures().run()

--- a/bugbot/rules/webcompat_score.py
+++ b/bugbot/rules/webcompat_score.py
@@ -95,7 +95,6 @@ class WebcompatScore(BzCleaner):
         return None
 
     def get_bz_params(self, date) -> dict[str, Any]:
-        fields = ["id", "cf_webcompat_score"]
         fields = ["id", "cf_webcompat_score", "cf_user_story"]
         self.scored_bugs = self.get_bug_scores()
         return {

--- a/scripts/cron_run_daily.sh
+++ b/scripts/cron_run_daily.sh
@@ -24,6 +24,9 @@ python -m bugbot.rules.perfalert_resolved_regression --production
 # Update the webcompat score fields
 python -m bugbot.rules.webcompat_score --production
 
+# Update the links in bugs associated with web features
+python -m bugbot.rules.web_platform_features --production
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m bugbot.log --send

--- a/templates/web_platform_features.html
+++ b/templates/web_platform_features.html
@@ -1,0 +1,32 @@
+<p>
+    The following {{ plural('bug is', data, pword='bugs are') }} are marked as for specific web-features, but were missing relevant see-also links:
+</p>
+<table {{ table_attrs }}>
+    <thead>
+        <tr>
+            <th>Bug</th>
+            <th>Links added</th>
+            <th>Summary</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for i, (bugid, summary, added) in enumerate(data) -%}
+            <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
+            {% endif -%}
+            >
+            <td>
+                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+            </td>
+            <td>
+                <ul>
+                    {% for link in added -%}
+                        <li>
+                            <a href="{{ link }}">{{ link | e }}</a>
+                        </li>
+                    {% endfor -%}
+                </ul>
+                <td>{{ summary | e }}</td>
+            </tr>
+        {% endfor -%}
+    </tbody>
+</table>


### PR DESCRIPTION
We generally want one platform bug for each web-feature we might implement. Once we know the web-feature associated with the bug, we can automatically ensure that we link to a lot of data about the feature, including the entry in the web-features-explorer and the spec URL. In some cases we also know the standards position, and can also ensure that's linked in the See Also field.

For simplicity the linked data we pull from BigQuery uses full string matches on the URLs, but for actual linking we just compare host and pathnames, so we don't duplicate links with different fragments or similar.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
