### PR TITLE
Fix virtual environment activation path for the cron jobs

### DIFF
--- a/scripts/cron_common_start.sh
+++ b/scripts/cron_common_start.sh
@@ -22,7 +22,7 @@ ErrorHandler() {
 
 trap ErrorHandler ERR
 
-. venv/bin/activate
+. .venv/bin/activate
 
 # force the update of dependencies
 uv sync --locked --no-dev


### PR DESCRIPTION
Changed the activation command from 'venv/bin/activate' to '.venv/bin/activate' to point to the environment created by `uv`.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
