### PR TITLE
Update Dependabot to use uv for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
Follow up on https://github.com/mozilla/bugbot/pull/2695

Changed the package-ecosystem from pip to uv in Dependabot configuration to manage Python dependencies. This aligns with the project's current dependency management approach.

Follow on on 

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
