### PR TITLE
Update bug last change time parsing logic

### DIFF
--- a/bugbot/rules/webcompat_platform_without_keyword.py
+++ b/bugbot/rules/webcompat_platform_without_keyword.py
@@ -5,6 +5,8 @@
 from datetime import datetime
 from typing import Any, Optional
 
+import dateutil
+
 from bugbot import gcp
 from bugbot.bzcleaner import BzCleaner
 
@@ -39,7 +41,7 @@ class WebcompatPlatformWithoutKeyword(BzCleaner):
         # so prefer to do nothing.
         if (
             self.last_bugzilla_import_time
-            and datetime.fromisoformat(bug["last_change_time"])
+            and dateutil.parser.parse(bug["last_change_time"])
             > self.last_bugzilla_import_time
         ):
             return None

--- a/bugbot/rules/webcompat_platform_without_keyword.py
+++ b/bugbot/rules/webcompat_platform_without_keyword.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 from typing import Any, Optional
 
-import dateutil
+from dateutil import parser
 
 from bugbot import gcp
 from bugbot.bzcleaner import BzCleaner
@@ -41,8 +41,7 @@ class WebcompatPlatformWithoutKeyword(BzCleaner):
         # so prefer to do nothing.
         if (
             self.last_bugzilla_import_time
-            and dateutil.parser.parse(bug["last_change_time"])
-            > self.last_bugzilla_import_time
+            and parser.parse(bug["last_change_time"]) > self.last_bugzilla_import_time
         ):
             return None
 


### PR DESCRIPTION
Fixes #2701

Replaces `datetime.fromisoformat` with `dateutil.parser.parse` for parsing `bug['last_change_time']`, ensuring UTC handling.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
