### PR TITLE
Update see_also field to use dict with 'add' key

### DIFF
--- a/bugbot/rules/web_platform_features.py
+++ b/bugbot/rules/web_platform_features.py
@@ -72,7 +72,7 @@ class WebPlatformFeatures(BzCleaner):
                 url for key, url in expected_keys.items() if key not in see_also_keys
             ]
             if add_urls:
-                changes["see_also"] = bug["see_also"] + add_urls
+                changes["see_also"] = {"add": add_urls}
                 data[bug_id]["added"] = add_urls
 
         if changes:


### PR DESCRIPTION
Fixes #2715 

Changed the assignment of the 'see_also' field to use a dictionary with an 'add' key instead of concatenating lists. Bugzilla only allows "add" and "remove" operations on list-type fields.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
