### PR TITLE
Remove mcastelluccio from receivers

### DIFF
--- a/configs/rules.json
+++ b/configs/rules.json
@@ -13,7 +13,6 @@
     "receivers": [
       "calixte@mozilla.com",
       "sylvestre@mozilla.com",
-      "mcastelluccio@mozilla.com",
       "smujahid@mozilla.com",
       "jwalker@mozilla.com"
     ],
@@ -431,7 +430,6 @@
     "confidence_threshold": 0.9,
     "cc": [
       "sledru@mozilla.com",
-      "mcastelluccio@mozilla.com",
       "cdenizet@mozilla.com"
     ]
   },


### PR DESCRIPTION
Being in the "common" receivers, it makes it hard for me to see the actual emails I should look at because they impact my team.

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
