### PR TITLE
Don't ask users for perf information when the "Performance Impact" is "none"

### DIFF
--- a/bugbot/rules/moved_to_performance.py
+++ b/bugbot/rules/moved_to_performance.py
@@ -158,6 +158,10 @@ class MovedToPerformance(BzCleaner):
             "f5": "longdesc",
             "o5": "casesubstring",
             "v5": "could you make sure the following information is on this bug?",
+            "n6": 1,
+            "f6": "cf_performance_impact",
+            "o6": "equals",
+            "v6": "none",
         }
 
         return params


### PR DESCRIPTION
Fixes #2444

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
