### PR TITLE
Send Android History, Application Update, and Installer bugs for automatic triage

### DIFF
--- a/bugbot/rules/frontend_triage.py
+++ b/bugbot/rules/frontend_triage.py
@@ -2,20 +2,30 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from bugbot import logger
+from bugbot import logger, utils
 from bugbot.bzcleaner import BzCleaner
 from bugbot.hackbot_utils import api_url, trigger_agent_run
 from bugbot.people import People
 
 AGENT = "frontend-triage"
 
+# The components the agent triages, as `(product, component)` pairs. Kept here rather
+# than in configs/rules.json on purpose: the agent's analysis lands on the bug
+# unattended, so widening its reach should take a code review.
+TRIAGED_COMPONENTS = (
+    ("Firefox", "New Tab Page"),
+    ("Firefox for Android", "History"),
+    ("Toolkit", "Application Update"),
+    ("Firefox", "Installer"),
+)
+
 
 class FrontendTriage(BzCleaner):
     """Ask hackbot's frontend-triage agent to triage newly filed frontend bugs.
 
-    Scoped to bugs filed by Mozilla staff (which includes QA) in
-    `Firefox :: New Tab Page`, because the agent's analysis is posted to the bug
-    unattended when it is confident. This rule only starts runs: the agent
+    Scoped to bugs filed by Mozilla staff (which includes QA) in the components
+    listed in `TRIAGED_COMPONENTS`, because the agent's analysis is posted to the
+    bug unattended when it is confident. This rule only starts runs: the agent
     investigates the source, comments on the bug, and reports to Slack itself, so
     nothing is written to Bugzilla from here.
     """
@@ -31,24 +41,26 @@ class FrontendTriage(BzCleaner):
         return "[Using AI] Bugs sent for automatic frontend triage"
 
     def columns(self):
-        return ["id", "summary", "creator", "run_id"]
+        return ["id", "summary", "product", "component", "creator", "run_id"]
 
     def has_default_products(self):
-        # The query names its own product; the 19-product default list would put
+        # The query names its own products; the 19-product default list would put
         # the whole tree in scope.
         return False
+
+    def has_product_component(self):
+        # `TRIAGED_COMPONENTS` spans three products, so "which component is this
+        # row about" is no longer obvious from the summary alone. Returning True
+        # gets both fields into `include_fields` and into every row for free
+        # (bzcleaner's `amend_bzparams` and `bughandler`), so unlike `creator`
+        # they need no stashing here.
+        return True
 
     def get_bz_params(self, date):
         start_date, _ = self.get_dates(date)
 
-        return {
+        params = {
             "include_fields": ["id", "summary", "creator"],
-            # Named literally, one product and one component: Bugzilla matches
-            # the two fields independently, so lists here would not express a
-            # product-to-component mapping. Widening to a second component means
-            # query groups, not another entry in a list.
-            "product": "Firefox",
-            "component": "New Tab Page",
             # Defects only: the agent triages broken behaviour, not feature work.
             "bug_type": "defect",
             "resolution": "---",
@@ -56,6 +68,30 @@ class FrontendTriage(BzCleaner):
             "o1": "greaterthan",
             "v1": start_date,
         }
+
+        # One AND group per pair, inside a top-level OR. Top-level `product` and
+        # `component` params are matched independently, so passing a list of each
+        # would also put every cross pairing in scope -- `Toolkit :: Installer`
+        # the day somebody creates it. No cross pairing exists today, but this
+        # rule spends money and posts to bugs unattended, so its reach should not
+        # be able to widen on its own.
+        n = utils.get_last_field_num(params)
+        params[f"j{n}"] = "OR"
+        params[f"f{n}"] = "OP"
+        for product, component in TRIAGED_COMPONENTS:
+            n = utils.get_last_field_num(params)
+            params[f"j{n}"] = "AND"
+            params[f"f{n}"] = "OP"
+            n = utils.get_last_field_num(params)
+            params.update({f"f{n}": "product", f"o{n}": "equals", f"v{n}": product})
+            n = utils.get_last_field_num(params)
+            params.update({f"f{n}": "component", f"o{n}": "equals", f"v{n}": component})
+            n = utils.get_last_field_num(params)
+            params[f"f{n}"] = "CP"
+        n = utils.get_last_field_num(params)
+        params[f"f{n}"] = "CP"
+
+        return params
 
     def handle_bug(self, bug, data):
         # The IAM roster covers QA too, now that they file from @mozilla.com

--- a/scripts/check_rules_on_wiki.py
+++ b/scripts/check_rules_on_wiki.py
@@ -56,7 +56,7 @@ class CheckWikiPage:
         # Experimental rules:
         "accessibilitybug.py",
         "performancebug.py",
-        "frontend_triage.py",  # piloting on one component before documenting it
+        "frontend_triage.py",  # piloting on a few components before documenting it
     }
 
     def __init__(self) -> None:

--- a/templates/frontend_triage.html
+++ b/templates/frontend_triage.html
@@ -6,12 +6,13 @@
         <tr>
             <th>Bug</th>
             <th>Summary</th>
+            <th>Component</th>
             <th>Reporter</th>
             <th>Run</th>
         </tr>
     </thead>
     <tbody>
-        {% for i, (bugid, summary, creator, run_id) in enumerate(data) -%}
+        {% for i, (bugid, summary, product, component, creator, run_id) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
@@ -19,6 +20,7 @@
                 <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
             </td>
             <td>{{ summary | e }}</td>
+            <td>{{ product | e }} :: {{ component | e }}</td>
             <td>{{ creator | e }}</td>
             <td>{{ run_id }}</td>
         </tr>

--- a/tests/rules/test_frontend_triage.py
+++ b/tests/rules/test_frontend_triage.py
@@ -7,7 +7,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from bugbot import hackbot_utils, utils
 from bugbot.people import People
-from bugbot.rules.frontend_triage import FrontendTriage
+from bugbot.rules.frontend_triage import TRIAGED_COMPONENTS, FrontendTriage
 
 STAFF_MAIL = "staffer@mozilla.com"
 QA_MAIL = "tester@mozilla.com"
@@ -54,6 +54,10 @@ def _bug(creator, bug_id=1):
         "id": bug_id,
         "summary": "New Tab weather widget vanishes",
         "creator": creator,
+        # `bughandler` copies these into the row because the rule sets
+        # `has_product_component()`, so they have to be here or it raises KeyError.
+        "product": "Firefox",
+        "component": "New Tab Page",
         # `amend_bzparams` adds `groups` to include_fields for every rule, and
         # `get_summary` reads it to redact security bugs.
         "groups": [],
@@ -120,13 +124,57 @@ def test_does_not_use_the_default_product_list():
     assert _rule().has_default_products() is False
 
 
-def test_queries_the_one_product_and_component():
-    # Not lists: Bugzilla matches product and component independently, so a pair
-    # of lists would claim a product-to-component mapping it doesn't enforce — a
-    # second product would pick up every component of that name across both.
+def _queried_pairs(params):
+    """Reconstruct the `(product, component)` pairs from the boolean chart.
+
+    Walks the numbered fields instead of asserting on `f7`/`v7` by name, so the
+    test still means something if the numbering shifts.
+    """
+    pairs = []
+    pending: dict = {}
+    for i in range(1, 100):
+        field = params.get(f"f{i}")
+        if field is None:
+            continue
+        if field == "OP":
+            pending = {}
+        elif field == "CP":
+            if {"product", "component"} <= pending.keys():
+                pairs.append((pending["product"], pending["component"]))
+            pending = {}
+        elif field in ("product", "component"):
+            assert params[f"o{i}"] == "equals"
+            pending[field] = params[f"v{i}"]
+    return pairs
+
+
+def test_queries_every_triaged_component():
     params = _rule().get_bz_params("2026-07-28")
-    assert params["product"] == "Firefox"
-    assert params["component"] == "New Tab Page"
+    assert _queried_pairs(params) == list(TRIAGED_COMPONENTS)
+
+
+def test_pairs_a_component_with_its_own_product():
+    # The regression this guards: `{"product": [...], "component": [...]}` would
+    # return the same bugs today, because Bugzilla matches the two fields
+    # independently and no cross pairing happens to exist -- and would silently
+    # widen the day somebody creates `Toolkit :: Installer`.
+    params = _rule().get_bz_params("2026-07-28")
+    assert "product" not in params
+    assert "component" not in params
+
+
+def test_ors_the_component_groups_and_ands_within_each():
+    params = _rule().get_bz_params("2026-07-28")
+    opens = [i for i in range(1, 100) if params.get(f"f{i}") == "OP"]
+    assert params[f"j{opens[0]}"] == "OR"
+    assert [params[f"j{i}"] for i in opens[1:]] == ["AND"] * len(TRIAGED_COMPONENTS)
+
+
+def test_spans_more_than_one_product():
+    # Not a tautology on the tuple: it is why the query needs groups at all, so if
+    # the scope ever narrows back to one product this test should be revisited
+    # rather than the groups being left in place unexplained.
+    assert len({product for product, _ in TRIAGED_COMPONENTS}) > 1
 
 
 def test_queries_only_open_defects():
@@ -139,10 +187,11 @@ def test_queries_only_recently_filed_bugs():
     rule = _rule()
     params = rule.get_bz_params("2026-07-28")
     start_date, _ = rule.get_dates("2026-07-28")
+    # `OP`/`CP` carry no operator or value, so the numbering is no longer dense.
     triplet = {
         (params[f"f{i}"], params[f"o{i}"], params[f"v{i}"])
-        for i in range(1, 10)
-        if f"f{i}" in params
+        for i in range(1, 100)
+        if f"o{i}" in params
     }
     assert ("creation_ts", "greaterthan", start_date) in triplet
 
@@ -294,6 +343,10 @@ def test_template_renders_a_row_per_triaged_bug(triggered):
     assert "show_bug.cgi?id=2" in html
     assert STAFF_MAIL in html
     assert "run-1" in html
+    # With three products in scope, the summary alone no longer says what a row is
+    # about. This also catches the template's positional unpacking going stale
+    # against `columns()`.
+    assert "Firefox :: New Tab Page" in html
 
 
 def test_template_reports_the_bugs_left_for_next_run(triggered):


### PR DESCRIPTION
## Problem

The frontend-triage pilot has been running against `Firefox :: New Tab Page` alone. This adds three more components and keeps New Tab Page:

| Product :: Component | Slack channel |
| --- | --- |
| `Firefox :: New Tab Page` | `#hnt-dev-triage` |
| `Firefox for Android :: History` | `#android-core-dev` |
| `Toolkit :: Application Update` | `#installer-updater-bug-triage` |
| `Firefox :: Installer` | `#installer-updater-bug-triage` |

Depends on **mozilla/bugbug#6585**, which adds those channels to the agent's `SLACK_CHANNELS` and widens its prompt past the desktop frontend. **That should land and deploy first.** Without it the new components have no channel entry, and `channel_for` failing closed silences the notification without stopping the run — the agent's analysis would still land on the bug unattended with nobody told.

## Change

The pairs now span three products, which the previous query shape could not express. `product` and `component` as top-level params are matched independently, so a list of each would also match every cross pairing — `Toolkit :: Installer` the day somebody creates it. So each pair gets its own AND group inside a top-level OR, built in a loop over a new `TRIAGED_COMPONENTS` tuple with `utils.get_last_field_num` rather than hand-numbered fields. That also leaves `amend_bzparams` free to append its `[no-nag]` filter after the closing `CP`, where it is ANDed with the whole group.

**To be clear about what this fixes: nothing, today.** I checked all twelve product/component combinations against BMO and none of the cross pairings exist, so the flat `{"product": [...], "component": [...]}` form would return exactly the same bugs right now. The groups are guarding against future silent widening, not repairing a current bug. It seemed worth the extra query complexity because this rule spends real LLM budget per bug and posts analysis to bugs unattended, so its reach should not be able to grow without a code review — which is also why `TRIAGED_COMPONENTS` is in the module rather than in `configs/rules.json`.

`has_product_component()` now returns `True` so the report names each bug's component: with three products in scope the summary alone no longer says what a row is about. `bzcleaner` puts both fields into `include_fields` and copies them into every row itself, so unlike `creator` they need no stashing in `handle_bug`.

`configs/rules.json` is unchanged. `max_triggers: 3` per hourly run is a 72/day ceiling, and the three new components saw 11 staff-filed defects in the last 90 days combined, so it is nowhere near binding.

## Testing

`pytest tests/`: 75 passed. In `tests/rules/test_frontend_triage.py` the old `test_queries_the_one_product_and_component` is replaced by four tests that reconstruct the `(product, component)` pairs by walking the numbered fields, rather than asserting on `f7`/`v7` by name, so they still mean something if the numbering shifts — plus one asserting the outer group is `OR` and each inner group is `AND`, and one pinning that `product`/`component` are absent as top-level params, which is the regression the groups exist to prevent.

Two existing tests needed adjusting, both consequences of the change rather than choices: `test_queries_only_recently_filed_bugs` assumed every `f{i}` has a matching `o{i}`, which `OP`/`CP` break, and the `_bug()` fixture needed `product`/`component` keys because `bughandler` now reads them.

`--dryrun` can't run in my sandbox — `configs/people.json` is gitignored and absent, which is why `People` is injectable in the first place. Instead I ran the real query against BMO with an injected roster. Over a six-month window it returns 299 bugs; all four pairs are represented and **nothing outside the intended pairs** comes back. Driving the full path through `handle_bug`, the dry-run branch of `trigger_runs`, `organize()`, and the template renders `Firefox :: Installer`, `Firefox :: New Tab Page`, and `Toolkit :: Application Update` cells correctly (Android History had no staff-filed bug in the window).

## Residual risk

**Two of the three new components are a poor fit for what the agent is prompted to do, and bugbug#6585 is a best guess at fixing that.** `Firefox for Android :: History` is Kotlin and `Firefox :: Installer` is NSIS, neither of which the agent had ever been pointed at. Install and update bugs also arrive as an error code and a log rather than a screenshot and steps to reproduce, which the ruleset previously treated as out of scope.

**Evidence will accumulate slowly.** ~11 staff-filed defects per 90 days across the three, so expect roughly one Fenix History bug per quarter. If the goal is to evaluate the agent on Android or install/update, the `People.is_mozilla` reporter filter is the throttle, not the component list — widening past staff reporters would be a separate decision.

**Cheap lever:** delete a line from `TRIAGED_COMPONENTS` to stop that component's runs at the source, or drop its `SLACK_CHANNELS` entry in bugbug to silence the notification while leaving triage on.

## Not doing

`Firefox :: Messaging System` was considered for this batch and deliberately left out.

The rule stays on `check_rules_on_wiki.py`'s experimental exemption list; only the stale "one component" wording in that comment changed.