### PR TITLE
Configure Firefox :: Messaging System bugs for automatic triage

### DIFF
--- a/bugbot/rules/frontend_triage.py
+++ b/bugbot/rules/frontend_triage.py
@@ -28,6 +28,7 @@ TRIAGED_COMPONENTS = (
     ("Firefox", "IP Protection"),
     ("Firefox for Android", "Toolbar"),
     ("Firefox for Android", "Homepage"),
+    ("Firefox", "Messaging System"),
 )
 
 


### PR DESCRIPTION
Configures `Firefox :: Messaging System` bugs for automatic triage.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
