### PR TITLE
Send Site Permissions bugs for automatic triage

### DIFF
--- a/bugbot/rules/frontend_triage.py
+++ b/bugbot/rules/frontend_triage.py
@@ -17,6 +17,7 @@ TRIAGED_COMPONENTS = (
     ("Firefox for Android", "History"),
     ("Toolkit", "Application Update"),
     ("Firefox", "Installer"),
+    ("Firefox", "Site Permissions"),
 )
 
 


### PR DESCRIPTION
## Problem

The frontend-triage pilot covers four `(product, component)` pairs: `Firefox :: New Tab Page`, `Firefox for Android :: History`, `Toolkit :: Application Update`, and `Firefox :: Installer`. This adds a fifth, `Firefox :: Site Permissions`, and keeps the other four.

Depends on mozilla/bugbug#6610. **That should land and deploy first.** Without it the component has no entry in the agent's `SLACK_CHANNELS`, and `channel_for` failing closed silences the notification without stopping the run — the analysis would still land on the bug with nobody told. That PR also tells the agent a Site Permissions bug can be in `extensions/permissions/PermissionManager.cpp` rather than under `browser/`, which is where a permission that does not persist is localized.

## Change

One pair added to `TRIAGED_COMPONENTS`. `get_bz_params` builds one AND group per pair in a loop over that tuple, so the new pair needs no query change, and `has_product_component()` already puts the component in the report rows.

The pair stays in code rather than `configs/rules.json` for the reason the existing comment gives: the agent's analysis lands on the bug unattended, so widening its reach should take a code review.

## Testing

`pytest tests/rules/test_frontend_triage.py` — 27 pass, unchanged. No test edits were needed: the pair-coverage tests derive from `TRIAGED_COMPONENTS` rather than restating it, so `test_queries_every_triaged_component` and `test_ors_the_component_groups_and_ands_within_each` pick the new pair up on their own, and `test_spans_more_than_one_product` still holds.

I could not run `--dryrun` locally, since it needs the gitignored `configs/people.json`. Instead I built the params through `get_bz_params`, widened the window to 90 days, and ran the generated boolean chart against BMO directly:

```
177 open defects
   147  Firefox :: New Tab Page
    15  Toolkit :: Application Update
     6  Firefox :: Installer
     6  Firefox for Android :: History
     3  Firefox :: Site Permissions
```

Three Site Permissions bugs returned and no cross pairing leaked in — no `Toolkit :: Installer`, no `Firefox :: History` — which is what the per-pair AND groups exist to prevent.

## Notes

`max_triggers` stays at 3. Site Permissions saw two staff-filed defects in the last 90 days, against 90 for New Tab Page over the same window, so the hourly cap is nowhere near binding.

`frontend_triage.py` keeps its entry in the `check_rules_on_wiki.py` exempt set — five components is still a pilot, not something to document on the wiki yet.