### PR TITLE
Move regression_new_set_nightly_affected to the daily cron

### DIFF
--- a/scripts/cron_run_daily.sh
+++ b/scripts/cron_run_daily.sh
@@ -31,4 +31,7 @@ python -m bugbot.rules.web_platform_features --production
 # MUST ALWAYS BE THE LAST COMMAND
 python -m bugbot.log --send
 
+# Set nightly status to affected on newly filed regressions
+python -m bugbot.rules.regression_new_set_nightly_affected --production
+
 source ./scripts/cron_common_end.sh

--- a/scripts/cron_run_weekdays.sh
+++ b/scripts/cron_run_weekdays.sh
@@ -190,9 +190,6 @@ python -m bugbot.rules.triage_rotations_outdated --production
 # Follow up on expiring variants
 python -m bugbot.rules.variant_expiration --production
 
-# Set nightly status to affected on newly filed regressions
-python -m bugbot.rules.regression_new_set_nightly_affected --production
-
 # Suggest increasing the severity of performance-impacting bugs
 python -m bugbot.rules.severity_high_performance_impact --production
 


### PR DESCRIPTION
~With the move to project metronome, once a week is too low a frequency for this rule so requesting to move it to daily~
With the move to project metronome, running this only on weekdays removes catching new regression in nightly versions over the weekend

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
