### PR TITLE
Limit security_affected_versions to defects

### DIFF
--- a/bugbot/rules/security_affected_versions.py
+++ b/bugbot/rules/security_affected_versions.py
@@ -147,6 +147,9 @@ class SecurityAffectedVersions(BzCleaner):
             # Only open bugs: we want to prompt while setting the flags is still
             # actionable (i.e. the patch is in review, not yet landed).
             "resolution": "---",
+            # Only defects: the "which branches are affected by this flaw"
+            # question doesn't apply to tasks or enhancements.
+            "bug_type": "defect",
             # Coarse recency filter: the bug changed within the window. Since
             # attaching a patch bumps `delta_ts`, this is a superset of "a patch
             # was attached within the window"; the precise per-attachment date


### PR DESCRIPTION
The security_affected_versions rule was running on all bug types, but we really only need this information for defects

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
