### PR TITLE
Send Android Toolbar and Homepage, IP Protection, and Sharing bugs for automatic triage

### DIFF
--- a/bugbot/rules/frontend_triage.py
+++ b/bugbot/rules/frontend_triage.py
@@ -12,12 +12,22 @@ AGENT = "frontend-triage"
 # The components the agent triages, as `(product, component)` pairs. Kept here rather
 # than in configs/rules.json on purpose: the agent's analysis lands on the bug
 # unattended, so widening its reach should take a code review.
+#
+# Every pair here needs a channel in the agent's own `TRIAGE_SCOPE` (bugbug's
+# agents/frontend-triage/hackbot_agents/frontend_triage/config.py), and the agent has to
+# be deployed with it first. `channel_for` fails closed, which silences the Slack
+# notification but not the run: the comment and the severity change still apply, so a
+# pair added here ahead of the agent gets unattended triage with nobody told. Nothing
+# checks this -- the two lists are in separate repos and cannot see each other.
 TRIAGED_COMPONENTS = (
     ("Firefox", "New Tab Page"),
     ("Firefox for Android", "History"),
     ("Toolkit", "Application Update"),
     ("Firefox", "Installer"),
     ("Firefox", "Site Permissions"),
+    ("Firefox", "IP Protection"),
+    ("Firefox for Android", "Toolbar"),
+    ("Firefox for Android", "Homepage"),
 )
 
 

--- a/bugbot/rules/frontend_triage.py
+++ b/bugbot/rules/frontend_triage.py
@@ -25,6 +25,7 @@ TRIAGED_COMPONENTS = (
     ("Toolkit", "Application Update"),
     ("Firefox", "Installer"),
     ("Firefox", "Site Permissions"),
+    ("Firefox", "Sharing"),
     ("Firefox", "IP Protection"),
     ("Firefox for Android", "Toolbar"),
     ("Firefox for Android", "Homepage"),

--- a/configs/rules.json
+++ b/configs/rules.json
@@ -422,7 +422,7 @@
   "frontend_triage": {
     "days_lookup": 1,
     "max_days_in_cache": 30,
-    "max_triggers": 3
+    "max_triggers": 5
   },
   "performancebug": {
     "max_days_in_cache": 7,


### PR DESCRIPTION
Four components join the set bugbot sends to hackbot's `frontend-triage` agent: `Firefox for Android :: Toolbar`, `Firefox for Android :: Homepage`, `Firefox :: IP Protection`, and `Firefox :: Sharing`. Each has a Slack channel on the agent side, and each of those channels exists and is public.

On this side that is three lines in `TRIAGED_COMPONENTS`. #2978 already did the generalization that makes it cheap: `get_bz_params` loops the tuple to build one AND group per pair inside a top-level OR, and the 27 tests derive from the tuple, so neither the query nor a test needs touching.

## Depends on mozilla/bugbug#6617

**That must be rolled out first.** `channel_for` on the agent side fails closed on a component missing from its registry, which silences the Slack notification but *not* the run — the analysis comment and the severity change still apply, so the component would get unattended triage with nobody told.

The gate is the deploy, not the merge. `scripts/cron_common_start.sh:20` checks out `$(… releases/latest … .tag_name)`, so this PR is inert on master and the release cut is the switch. Merging it early is harmless; cutting a release before #6617 is live is not.

Because that constraint has until now lived only in commit messages (8bbbc55, #2991), it is written into the comment above `TRIAGED_COMPONENTS` in this PR. Nothing checks that the two lists agree and nothing can — they are in separate repos and cannot see each other, which is deliberate: the comment says the reach lives in code so that widening it takes a code review, and a runtime fetch would let a bugbug commit widen what bugbot sends with no review here.

## The query does not widen accidentally

I ran the generated boolean chart against BMO over 90 days: 263 open defects across the eight pairs before Sharing, up from 178, and the per-component counts match individual queries exactly. No cross pairing appeared, and none is currently possible — BMO has no `Firefox :: Homepage` and no `Firefox :: Toolbar` (the desktop component is `Toolbars and Customization`), and `IP Protection` and `Sharing` exist only under `Firefox`. That is today's state rather than a guarantee, which is exactly why `get_bz_params` builds per-pair AND groups instead of passing flat `product`/`component` lists.

Staff-filed volume over 90 days, using a reporter-contains-`@mozilla.com` approximation (it reproduced the "90 for New Tab Page" figure in 8bbbc55):

| Component | Open defects / 90d | Staff-filed |
| --- | --- | --- |
| `Firefox :: Sharing` | 38 | 34 |
| `Firefox for Android :: Homepage` | 35 | 24 |
| `Firefox :: IP Protection` | 32 | 22 |
| `Firefox for Android :: Toolbar` | 18 | 2 |

## `max_triggers` 3 → 5

This is a per-run cap and the rule runs hourly, so the ceiling goes from 72 to 120 runs a day against staff-filed demand of roughly 2.24/day across the nine components now in scope. Steady state is unaffected — the cap has never bound at that rate. What changes is burst drain: ten bugs from one QA session cleared over four hourly runs at 3 and clears in two at 5, and every run that held bugs back already reported them in the email as `left_for_next_run` rather than losing them.

The cost is the other thing this cap bounds. It is also the limit on how many unreviewed Bugzilla comments a bad prompt or ruleset change can produce in one hour before anyone notices, so that worst case goes from 3 to 5.

## Testing

`uv run pytest tests/rules/test_frontend_triage.py` — 27 pass, unchanged. `uv run pytest tests/` — 75 pass.

No test changes were needed, which is the point of #2978's design: `test_queries_every_triaged_component` compares the reconstructed chart to `list(TRIAGED_COMPONENTS)`, `test_ors_the_component_groups_and_ands_within_each` derives its expected length from it, and `test_pairs_a_component_with_its_own_product` is the regression guard for the cross-pairing widening described above. Both cap tests set `max_triggers` explicitly rather than reading `configs/rules.json`, so the 3 → 5 change does not touch them.

I could not run `python -m bugbot.rules.frontend_triage --dryrun`: it needs the gitignored `configs/people.json`, which is absent here. The BMO chart check above is what stands in for it.

## Scope

Nothing else in this repo is keyed by component. `templates/frontend_triage.html` renders `Product :: Component` generically because `has_product_component()` returns True, and `scripts/check_rules_on_wiki.py` still exempts this rule while it is piloting. `configs/rules.json` changes only for `max_triggers`.
