### PR TITLE
Limit no_crashes to defects

### DIFF
--- a/bugbot/rules/no_crashes.py
+++ b/bugbot/rules/no_crashes.py
@@ -38,6 +38,7 @@ class NoCrashes(BzCleaner):
         fields = ["cf_crash_signature"]
         params = {
             "include_fields": fields,
+            "bug_type": "defect",
             "resolution": "---",
             "status": ["UNCONFIRMED", "NEW", "ASSIGNED"],
             "f1": "cf_crash_signature",


### PR DESCRIPTION
The no_crashes rule was running on all bug types, but should be restricted to defects only.

note: dry run returns no results with or without "bug_type" filter:
```
2026-09-02 09:27:57,709 - INFO - NO_CRASHES: No data for 2026-09-02
```

fixes #2871 

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
