### PR TITLE
Configure Firefox :: Sidebar and Firefox :: Settings UI bugs for automatic triage

### DIFF
--- a/bugbot/rules/frontend_triage.py
+++ b/bugbot/rules/frontend_triage.py
@@ -30,6 +30,8 @@ TRIAGED_COMPONENTS = (
     ("Firefox for Android", "Homepage"),
     ("Firefox", "Messaging System"),
     ("Toolkit", "Data Sanitization"),
+    ("Firefox", "Sidebar"),
+    ("Firefox", "Settings UI"),
 )
 
 


### PR DESCRIPTION
The agent's `TRIAGE_SCOPE` routes these two components to #p10y-bots and #fx-recomp-bots, which mozilla/bugbug#6761 adds, so the pairs can start arriving here once that is deployed. Nothing checks the two lists against each other: they are in separate repos and `channel_for` fails closed, so a pair added ahead of the agent gets unattended triage with nobody told.

Depends on mozilla/bugbug#6761. **That should deploy first.**