### PR TITLE
security_affected_versions should skip bugs that have a regressed by bug

### DIFF
--- a/bugbot/rules/security_affected_versions.py
+++ b/bugbot/rules/security_affected_versions.py
@@ -173,12 +173,17 @@ class SecurityAffectedVersions(BzCleaner):
             "f4": "longdesc",
             "o4": "casesubstring",
             "v4": NEEDINFO_QUESTION,
+            # No regressor: skip when `regressed_by` is set, to avoid racing
+            # with the `regression_set_status_flags` rule, which sets
+            # those flags automatically from the regressor.
+            "f5": "regressed_by",
+            "o5": "isempty",
             # At least one relevant release status flag is still empty (unset).
-            "f5": "OP",
-            "j5": "OR",
+            "f6": "OP",
+            "j6": "OR",
         }
 
-        i = 6
+        i = 7
         for flag in self.status_flags:
             params[f"f{i}"] = flag
             params[f"o{i}"] = "equals"


### PR DESCRIPTION
security_affected_versions can race with the regression_set_status_flags, we shoudl ignore bugs that have a regressed by bug already set 

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
