### PR TITLE
Configure the three Core :: Machine Learning components for automatic triage

### DIFF
--- a/bugbot/rules/frontend_triage.py
+++ b/bugbot/rules/frontend_triage.py
@@ -32,6 +32,9 @@ TRIAGED_COMPONENTS = (
     ("Toolkit", "Data Sanitization"),
     ("Firefox", "Sidebar"),
     ("Firefox", "Settings UI"),
+    ("Core", "Machine Learning: Frontend"),
+    ("Core", "Machine Learning: Models"),
+    ("Core", "Machine Learning: General"),
 )
 
 


### PR DESCRIPTION
The agent gets channels for these three in mozilla/bugbug#6789, so the hourly rule can start sending it Smart Window bugs. They are the first Core pairs and the first component names containing a colon, neither of which the query construction cares about.

**That must deploy first**: `channel_for` fails closed, so a pair here ahead of the agent gets unattended triage with nobody told.